### PR TITLE
Optimized IsZero and IsOne

### DIFF
--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -493,4 +493,26 @@ namespace Nethermind.Int256.Benchmark
             return res;
         }
     }
+
+    [SimpleJob(RuntimeMoniker.NetCoreApp50)]
+    [MemoryDiagnoser]
+    public class IsZeroOne
+    {
+        public UInt256[] Values { get; } = {UInt256.Zero, UInt256.One, UInt256.MaxValue};
+
+        [ParamsSource(nameof(Values))]
+        public UInt256 A;
+
+        [Benchmark]
+        public bool IsZero()
+        {
+            return A.IsZero;
+        }
+        
+        [Benchmark]
+        public bool IsOne()
+        {
+            return A.IsOne;
+        }
+    }
 }

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -273,12 +273,14 @@ namespace Nethermind.Int256
 
         public (ulong value, bool overflow) UlongWithOverflow => (this.u0, (this.u1 | this.u2 | this.u3) != 0);
 
-        public bool IsZero => this == Zero;
+        public bool IsZero => (u0 | u1 | u2 | u3) == 0;
+        
+        public bool IsOne => ((u0 ^ 1UL) | u1 | u2 | u3) == 0;
+
+        public bool IsZeroOrOne => ((u0 >> 1) | u1 | u2 | u3) == 0;
 
         public UInt256 ZeroValue => Zero;
-
-        public bool IsOne => this == One;
-
+        
         public UInt256 OneValue => One;
 
         public UInt256 MaximalValue => MaxValue;
@@ -411,7 +413,7 @@ namespace Nethermind.Int256
         // If y == 0, z is set to 0 (OBS: differs from the big.Int)
         public static void Mod(in UInt256 x, in UInt256 y, out UInt256 res)
         {
-            if (x.IsZero || y.IsZero || y.IsOne)
+            if (x.IsZero || y.IsZeroOrOne)
             {
                 res = Zero;
                 return;


### PR DESCRIPTION
This PR optimizes `IsZero` and `IsOne` that is called in many methods. The initial overhead wasn't absolutely big, but I found it when working on `Divide` and related methods. The outcome of this PR makes  _The method duration indistinguishable from the empty method duration_.

### Setup

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1316 (1909/November2018Update/19H2)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.103
  [Host]        : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT
  .NET Core 5.0 : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT

Job=.NET Core 5.0  Runtime=.NET Core 5.0  

```

### Before

| Method |                    A |      Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |--------------------- |----------:|----------:|----------:|------:|------:|------:|----------:|
| **IsZero** |                    **0** | **1.3511 ns** | **0.0703 ns** | **0.1074 ns** |     **-** |     **-** |     **-** |         **-** |
|  IsOne |                    0 | 0.5913 ns | 0.0544 ns | 0.0745 ns |     - |     - |     - |         - |
| **IsZero** |                    **1** | **0.7594 ns** | **0.0538 ns** | **0.0552 ns** |     **-** |     **-** |     **-** |         **-** |
|  IsOne |                    1 | 1.8782 ns | 0.0775 ns | 0.1137 ns |     - |     - |     - |         - |
| **IsZero** | **11579(...)39935 [78]** | **0.7423 ns** | **0.0400 ns** | **0.0355 ns** |     **-** |     **-** |     **-** |         **-** |
|  IsOne | 11579(...)39935 [78] | 0.6045 ns | 0.0379 ns | 0.0336 ns |     - |     - |     - |         - |

### After

| Method |                    A |      Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |--------------------- |----------:|----------:|----------:|------:|------:|------:|----------:|
| **IsZero** |                    **0** | **0.0506 ns** | **0.0322 ns** | **0.0301 ns** |     **-** |     **-** |     **-** |         **-** |
|  IsOne |                    0 | 0.3277 ns | 0.0409 ns | 0.0517 ns |     - |     - |     - |         - |
| **IsZero** |                    **1** | **0.0517 ns** | **0.0330 ns** | **0.0308 ns** |     **-** |     **-** |     **-** |         **-** |
|  IsOne |                    1 | 0.2898 ns | 0.0425 ns | 0.0568 ns |     - |     - |     - |         - |
| **IsZero** | **11579(...)39935 [78]** | **0.4194 ns** | **0.0464 ns** | **0.0860 ns** |     **-** |     **-** |     **-** |         **-** |
|  IsOne | 11579(...)39935 [78] | 0.0940 ns | 0.0333 ns | 0.0556 ns |     - |     - |     - |         - |
