### PR TITLE
Deterministic benchmarks parameters

### DIFF
--- a/src/Nethermind.Int256.Test/UnaryOps.cs
+++ b/src/Nethermind.Int256.Test/UnaryOps.cs
@@ -66,9 +66,11 @@ namespace Nethermind.Int256.Test
 
         public static IEnumerable<int> ShiftTestCases => Enumerable.Range(0, 257);
 
+        const int Seed = 0;
+        
         public static IEnumerable<BigInteger> RandomSigned(int count)
         {
-            var rand = new System.Random();
+            var rand = new System.Random(Seed);
             byte[] data = new byte[256 / 8];
             for (int i = 0; i < count; i++)
             {
@@ -79,7 +81,7 @@ namespace Nethermind.Int256.Test
 
         public static IEnumerable<BigInteger> RandomUnsigned(int count)
         {
-            var rand = new System.Random();
+            var rand = new System.Random(Seed);
             byte[] data = new byte[256 / 8];
             for (int i = 0; i < count; i++)
             {
@@ -91,7 +93,7 @@ namespace Nethermind.Int256.Test
 
         public static IEnumerable<int> RandomInt(int count)
         {
-            var rand = new System.Random();
+            var rand = new System.Random(Seed);
             for (int i = 0; i < count; i++)
             {
                 yield return rand.Next();


### PR DESCRIPTION
This PR changes the way `Random` is initialized for benchmarks providing a constant `Seed` value. The reason for this is to use a repeatable source of data and make comparison more reliable. Previously, depending on a global seed execution could be drastically different.

One could argue that now the randomized output is the same for all calls to `Random*` across all the benchmarks. As I know no easy way to obtain the benchmark name and base the seed on it, I think this approach is much better than having a totally random value in here. It's utterly boring, but stable 😉 