### PR TITLE
Uint256 Divide speed up

### DIFF
--- a/src/Nethermind.Int256/Nethermind.Int256.csproj
+++ b/src/Nethermind.Int256/Nethermind.Int256.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
@@ -6,6 +6,7 @@
         <LangVersion>9</LangVersion>
         <Deterministic>true</Deterministic>
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
 </Project>

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -591,7 +591,7 @@ namespace Nethermind.Int256
             Span<ulong> dnS = stackalloc ulong[4] { dn0, dn1, dn2, dn3 };
             dnS = dnS.Slice(0, dLen);
 
-            UdivremKnuth(MemoryMarshal.CreateSpan(ref quot, length), un, dnS); //TODO: scooletz, replace create span with a proper by ref
+            UdivremKnuth(ref quot, un, dnS);
 
             ulong rem0 = 0, rem1 = 0, rem2 = 0, rem3 = 0;
             switch (dLen)
@@ -625,7 +625,7 @@ namespace Nethermind.Int256
         // The quotient is stored in provided quot - len(u)-len(d) words.
         // Updates u to contain the remainder - len(d) words.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void UdivremKnuth(Span<ulong> quot, Span<ulong> u, Span<ulong> d)
+        private static void UdivremKnuth(ref ulong quot, Span<ulong> u, Span<ulong> d)
         {
             var dh = d[d.Length - 1];
             var dl = d[d.Length - 2];
@@ -664,7 +664,7 @@ namespace Nethermind.Int256
                     u[j + d.Length] += AddTo(u.Slice(j), d);
                 }
 
-                quot[j] = qhat; // Store quotient digit.
+                Unsafe.Add(ref quot, j) = qhat; // Store quotient digit.
             }
         }
 

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1062,12 +1062,9 @@ namespace Nethermind.Int256
             // At this point, we know
             // x/y ; x > y > 0
 
-            res = default;
+            res = default; // initialize with zeros
             const int length = 4;
-            Span<ulong> quot = stackalloc ulong[length];
-            Span<ulong> xSpan = stackalloc ulong[length] { x.u0, x.u1, x.u2, x.u3 };
-            Udivrem(ref MemoryMarshal.GetReference(quot), ref MemoryMarshal.GetReference(xSpan), length, y, out UInt256 _);
-            res = new UInt256(quot);
+            Udivrem(ref Unsafe.As<UInt256, ulong>(ref res), ref Unsafe.As<UInt256, ulong>(ref Unsafe.AsRef(in x)), length, y, out UInt256 _);
         }
 
         public void Divide(in UInt256 a, out UInt256 res) => Divide(this, a, out res);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -339,9 +339,10 @@ namespace Nethermind.Int256
 
             if (AddOverflow(x, y, out res))
             {
-                Span<ulong> sum = stackalloc ulong[5] { res.u0, res.u1, res.u2, res.u3, 1 };
-                Span<ulong> quot = stackalloc ulong[5];
-                Udivrem(quot, sum, in m, out res);
+                const int length = 5;
+                Span<ulong> sum = stackalloc ulong[length] { res.u0, res.u1, res.u2, res.u3, 1 };
+                Span<ulong> quot = stackalloc ulong[length];
+                Udivrem(ref MemoryMarshal.GetReference(quot), ref MemoryMarshal.GetReference(sum), length, in m, out res);
             }
             else
             {
@@ -440,9 +441,10 @@ namespace Nethermind.Int256
                 return;
             }
 
-            Span<ulong> quot = stackalloc ulong[4];
-            Span<ulong> xSpan = stackalloc ulong[4] { x.u0, x.u1, x.u2, x.u3 };
-            Udivrem(quot, xSpan, y, out res);
+            const int length = 4;
+            Span<ulong> quot = stackalloc ulong[length];
+            Span<ulong> xSpan = stackalloc ulong[length] { x.u0, x.u1, x.u2, x.u3 };
+            Udivrem(ref MemoryMarshal.GetReference(quot), ref MemoryMarshal.GetReference(xSpan), length, y, out res);
         }
 
         public void Mod(in UInt256 m, out UInt256 res) => Mod(this, m, out res);
@@ -514,7 +516,7 @@ namespace Nethermind.Int256
         // It loosely follows the Knuth's division algorithm (sometimes referenced as "schoolbook" division) using 64-bit words.
         // See Knuth, Volume 2, section 4.3.1, Algorithm D.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Udivrem(Span<ulong> quot, Span<ulong> u, in UInt256 d, out UInt256 rem)
+        private static void Udivrem(ref ulong quot, ref ulong u, int length, in UInt256 d, out UInt256 rem)
         {
             int dLen = 0;
             int shift = 0;
@@ -540,9 +542,9 @@ namespace Nethermind.Int256
             }
 
             int uLen = 0;
-            for (int i = u.Length - 1; i >= 0; i--)
+            for (int i = length - 1; i >= 0; i--)
             {
-                if (u[i] != 0)
+                if (Unsafe.Add(ref u,i) != 0)
                 {
                     uLen = i + 1;
                     break;
@@ -551,20 +553,20 @@ namespace Nethermind.Int256
 
             Span<ulong> un = stackalloc ulong[9];
             un = un.Slice(0, uLen + 1);
-            un[uLen] = Rsh(u[uLen - 1], 64 - shift);
+            un[uLen] = Rsh(Unsafe.Add(ref u, uLen - 1), 64 - shift);
             for (int i = uLen - 1; i > 0; i--)
             {
-                un[i] = Lsh(u[i], shift) | Rsh(u[i - 1], 64 - shift);
+                un[i] = Lsh(Unsafe.Add(ref u, i), shift) | Rsh(Unsafe.Add(ref u, i - 1), 64 - shift);
             }
 
-            un[0] = Lsh(u[0], shift);
+            un[0] = Lsh(u, shift);
 
             // TODO: Skip the highest word of numerator if not significant.
 
             if (dLen == 1)
             {
                 ulong dnn0 = Lsh(d.u0, shift);
-                ulong r = UdivremBy1(quot, un, dnn0);
+                ulong r = UdivremBy1(MemoryMarshal.CreateSpan(ref quot, length), un, dnn0); //TODO: scooletz, replace create span with a proper by ref
                 r = Rsh(r, shift);
                 rem = (UInt256)r;
                 return;
@@ -589,7 +591,7 @@ namespace Nethermind.Int256
             Span<ulong> dnS = stackalloc ulong[4] { dn0, dn1, dn2, dn3 };
             dnS = dnS.Slice(0, dLen);
 
-            UdivremKnuth(quot, un, dnS);
+            UdivremKnuth(MemoryMarshal.CreateSpan(ref quot, length), un, dnS); //TODO: scooletz, replace create span with a proper by ref
 
             ulong rem0 = 0, rem1 = 0, rem2 = 0, rem3 = 0;
             switch (dLen)
@@ -935,13 +937,14 @@ namespace Nethermind.Int256
                 return;
             }
 
-            Span<ulong> p = stackalloc ulong[8];
+            const int length = 8;
+            Span<ulong> p = stackalloc ulong[length];
             var pLow = p.Slice(0, 4);
             pl.ToSpan(ref pLow);
             var pHigh = p.Slice(4, 4);
             ph.ToSpan(ref pHigh);
-            Span<ulong> quot = stackalloc ulong[8];
-            Udivrem(quot, p, m, out res);
+            Span<ulong> quot = stackalloc ulong[length];
+            Udivrem(ref MemoryMarshal.GetReference(quot), ref MemoryMarshal.GetReference(p), length, m, out res);
         }
 
         public void MultiplyMod(in UInt256 a, in UInt256 m, out UInt256 res) => MultiplyMod(this, a, m, out res);
@@ -1059,9 +1062,11 @@ namespace Nethermind.Int256
             // At this point, we know
             // x/y ; x > y > 0
 
-            Span<ulong> quot = stackalloc ulong[4];
-            Span<ulong> xSpan = stackalloc ulong[4] { x.u0, x.u1, x.u2, x.u3 };
-            Udivrem(quot, xSpan, y, out UInt256 _);
+            res = default;
+            const int length = 4;
+            Span<ulong> quot = stackalloc ulong[length];
+            Span<ulong> xSpan = stackalloc ulong[length] { x.u0, x.u1, x.u2, x.u3 };
+            Udivrem(ref MemoryMarshal.GetReference(quot), ref MemoryMarshal.GetReference(xSpan), length, y, out UInt256 _);
             res = new UInt256(quot);
         }
 

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -443,8 +443,7 @@ namespace Nethermind.Int256
 
             const int length = 4;
             Span<ulong> quot = stackalloc ulong[length];
-            Span<ulong> xSpan = stackalloc ulong[length] { x.u0, x.u1, x.u2, x.u3 };
-            Udivrem(ref MemoryMarshal.GetReference(quot), ref MemoryMarshal.GetReference(xSpan), length, y, out res);
+            Udivrem(ref MemoryMarshal.GetReference(quot), ref Unsafe.As<UInt256, ulong>(ref Unsafe.AsRef(in x)), length, y, out res);
         }
 
         public void Mod(in UInt256 m, out UInt256 res) => Mod(this, m, out res);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -566,7 +566,7 @@ namespace Nethermind.Int256
             if (dLen == 1)
             {
                 ulong dnn0 = Lsh(d.u0, shift);
-                ulong r = UdivremBy1(MemoryMarshal.CreateSpan(ref quot, length), un, dnn0); //TODO: scooletz, replace create span with a proper by ref
+                ulong r = UdivremBy1(ref quot, un, dnn0);
                 r = Rsh(r, shift);
                 rem = (UInt256)r;
                 return;
@@ -699,14 +699,14 @@ namespace Nethermind.Int256
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong UdivremBy1(Span<ulong> quot, Span<ulong> u, ulong d)
+        private static ulong UdivremBy1(ref ulong quot, Span<ulong> u, ulong d)
         {
             var reciprocal = Reciprocal2by1(d);
             ulong rem;
             rem = u[u.Length - 1]; // Set the top word as remainder.
             for (int j = u.Length - 2; j >= 0; j--)
             {
-                (quot[j], rem) = Udivrem2by1(rem, u[j], d, reciprocal);
+                (Unsafe.Add(ref quot, j), rem) = Udivrem2by1(rem, u[j], d, reciprocal);
             }
 
             return rem;

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -551,8 +551,7 @@ namespace Nethermind.Int256
                 }
             }
 
-            Span<ulong> un = stackalloc ulong[9];
-            un = un.Slice(0, uLen + 1);
+            Span<ulong> un = stackalloc ulong[uLen + 1];
             un[uLen] = Rsh(Unsafe.Add(ref u, uLen - 1), 64 - shift);
             for (int i = uLen - 1; i > 0; i--)
             {


### PR DESCRIPTION
This PR speeds up `Divide` method. Depending on the benchmark case, the speedup is bigger or smaller providing at least 15% speed up.

Most of the work was based on:

- moving to `Unsafe`/`ByRef` land
- minimizing `stackalloc` of `Span<ulong>`
- skipping `ctor` of `UInt256` by directly writing over `readonly` fields

It's hard to separate changes and make them measurable one by one. At the same time I'm not sure if it's worth it to split work into multiple PRs.

### Remarks

Numbers below compare the state before #12 with the current one. It might look like cheating to show better numbers, but as far as I understand ASM Jitted underneath a lot of inlining happens with the changes so I try to compare the actual gain for the whole `Divide`.

Is this the end? I think there are still some options in here:

- `SkipInit` for stack allocated values (or attribute for whole method)
- more `ByRef` for the rest of the `Span`s
- make `Udivrem` generally simpler, because it's still not inlined
  - revisit and review flow control for `Udivrem` 
  - remove ctor call at the end `rem = new UInt256(rem0, rem1, rem2, rem3);`
  - unbranch it with vectors maybe?

### Setup

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1316 (1909/November2018Update/19H2)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.103
  [Host]        : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT
  .NET Core 5.0 : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT

Job=.NET Core 5.0  Runtime=.NET Core 5.0  

```

### Before

|         Method |                   A |                   B |       Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |-------------------- |-------------------- |-----------:|----------:|----------:|------:|------:|------:|----------:|
| **Divide_UInt256** | **(115(...)935) [160]** | **(115(...)935) [160]** |   **9.544 ns** | **0.2089 ns** | **0.1954 ns** |     **-** |     **-** |     **-** |         **-** |
| **Divide_UInt256** | **(115(...)935) [160]** | **(619(...)658) [156]** | **140.594 ns** | **2.8636 ns** | **5.3079 ns** |     **-** |     **-** |     **-** |         **-** |
| **Divide_UInt256** | **(619(...)658) [156]** | **(115(...)935) [160]** |   **8.235 ns** | **0.1173 ns** | **0.1097 ns** |     **-** |     **-** |     **-** |         **-** |
| **Divide_UInt256** | **(619(...)658) [156]** | **(619(...)658) [156]** |  **10.901 ns** | **0.2587 ns** | **0.2875 ns** |     **-** |     **-** |     **-** |         **-** |

### After

|         Method |                   A |                   B |       Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |-------------------- |-------------------- |-----------:|----------:|----------:|------:|------:|------:|----------:|
| **Divide_UInt256** | **(115(...)935) [160]** | **(115(...)935) [160]** |   **6.955 ns** | **0.1352 ns** | **0.1758 ns** |     **-** |     **-** |     **-** |         **-** |
| **Divide_UInt256** | **(115(...)935) [160]** | **(619(...)658) [156]** | **120.607 ns** | **1.9074 ns** | **1.7842 ns** |     **-** |     **-** |     **-** |         **-** |
| **Divide_UInt256** | **(619(...)658) [156]** | **(115(...)935) [160]** |   **5.283 ns** | **0.1150 ns** | **0.1076 ns** |     **-** |     **-** |     **-** |         **-** |
| **Divide_UInt256** | **(619(...)658) [156]** | **(619(...)658) [156]** |   **7.002 ns** | **0.1616 ns** | **0.1796 ns** |     **-** |     **-** |     **-** |         **-** |