### PR TITLE
Multiply64 optimized with Math.BigMul

### DIFF
--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1019,17 +1019,7 @@ namespace Nethermind.Int256
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static (ulong high, ulong low) Multiply64(ulong a, ulong b)
         {
-            ulong a0 = (uint)a;
-            ulong a1 = a >> 32;
-            ulong b0 = (uint)b;
-            ulong b1 = b >> 32;
-            ulong carry = a0 * b0;
-            uint r0 = (uint)carry;
-            carry = (carry >> 32) + a0 * b1;
-            ulong r2 = carry >> 32;
-            carry = (uint)carry + a1 * b0;
-            var low = carry << 32 | r0;
-            var high = (carry >> 32) + r2 + a1 * b1;
+            ulong high = Math.BigMul(a, b, out ulong low);
             return (high, low);
         }
 


### PR DESCRIPTION
This PR replaces the existing body of `Multiply64` with a direct call to `Math.BigMul`. Underneath `Math.BigMul`, if supported, uses `Bmi2.X64.MultiplyNoFlags`. As `Multiply64` is used transitively in `Udivrem`, this can be a huge change. Benchmarks are provided only  for `Multiply_UInt256` though.

### Setup

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1316 (1909/November2018Update/19H2)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.103
  [Host]        : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT
  .NET Core 5.0 : .NET Core 5.0.3 (CoreCLR 5.0.321.7212, CoreFX 5.0.321.7212), X64 RyuJIT

Job=.NET Core 5.0  Runtime=.NET Core 5.0  

```

### Before

|           Method |                   A |                   B |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |-------------------- |-------------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
| **Multiply_UInt256** | **(115(...)935) [160]** | **(115(...)935) [160]** | **28.50 ns** | **0.537 ns** | **0.996 ns** |     **-** |     **-** |     **-** |         **-** |
| **Multiply_UInt256** | **(115(...)935) [160]** | **(619(...)658) [156]** | **29.34 ns** | **0.625 ns** | **1.732 ns** |     **-** |     **-** |     **-** |         **-** |
| **Multiply_UInt256** | **(619(...)658) [156]** | **(115(...)935) [160]** | **28.94 ns** | **0.620 ns** | **0.715 ns** |     **-** |     **-** |     **-** |         **-** |
| **Multiply_UInt256** | **(619(...)658) [156]** | **(619(...)658) [156]** | **29.87 ns** | **0.638 ns** | **1.540 ns** |     **-** |     **-** |     **-** |         **-** |

### After

|           Method |                   A |                   B |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |-------------------- |-------------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
| **Multiply_UInt256** | **(115(...)935) [160]** | **(115(...)935) [160]** | **19.08 ns** | **0.266 ns** | **0.236 ns** |     **-** |     **-** |     **-** |         **-** |
| **Multiply_UInt256** | **(115(...)935) [160]** | **(619(...)658) [156]** | **18.90 ns** | **0.424 ns** | **0.696 ns** |     **-** |     **-** |     **-** |         **-** |
| **Multiply_UInt256** | **(619(...)658) [156]** | **(115(...)935) [160]** | **18.61 ns** | **0.330 ns** | **0.309 ns** |     **-** |     **-** |     **-** |         **-** |
| **Multiply_UInt256** | **(619(...)658) [156]** | **(619(...)658) [156]** | **18.35 ns** | **0.403 ns** | **0.377 ns** |     **-** |     **-** |     **-** |         **-** |