### PR TITLE
fix: UInt256: Divide, Lsh, Rsh, Exp, ExpMod, SubtractMod; Int256: Multiply - when in and out params are referenced to the same struct

### DIFF
--- a/src/Nethermind.Int256.Test/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Test/UInt256Tests.cs
@@ -33,6 +33,11 @@ namespace Nethermind.Int256.Test
             res.Convert(out BigInteger resUInt256);
 
             resUInt256.Should().Be(resBigInt);
+
+            a.Add(b, out a);
+            a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
         }
 
         [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.TestCases))]
@@ -50,6 +55,19 @@ namespace Nethermind.Int256.Test
 
             resUInt256.Should().Be(resBigInt);
 
+            if (test.A + test.B <= (BigInteger)UInt256.MaxValue)
+            {
+                overflow.Should().Be(false);
+            }
+            else
+            {
+                overflow.Should().Be(true);
+            }
+
+            overflow = T.AddOverflow(uint256a, uint256b, out uint256a);
+            uint256a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
             if (test.A + test.B <= (BigInteger)UInt256.MaxValue)
             {
                 overflow.Should().Be(false);
@@ -78,6 +96,11 @@ namespace Nethermind.Int256.Test
             res.Convert(out BigInteger resUInt256);
 
             resUInt256.Should().Be(resBigInt);
+
+            uint256a.AddMod(uint256b, uint256m, out uint256a);
+            uint256a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
         }
 
         [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.TestCases))]
@@ -96,6 +119,11 @@ namespace Nethermind.Int256.Test
             T uint256b = convert(test.B);
             uint256a.Subtract(uint256b, out T res);
             res.Convert(out BigInteger resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
+
+            uint256a.Subtract(uint256b, out uint256a);
+            uint256a.Convert(out resUInt256);
 
             resUInt256.Should().Be(resBigInt);
         }
@@ -130,6 +158,11 @@ namespace Nethermind.Int256.Test
             res.Convert(out BigInteger resUInt256);
 
             resUInt256.Should().Be(resBigInt);
+
+            uint256a.SubtractMod(uint256b, uint256m, out uint256a);
+            uint256a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
         }
 
         [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.TestCases))]
@@ -148,13 +181,18 @@ namespace Nethermind.Int256.Test
                 {
                     UInt256 res = a - b;
                     res.Convert(out resUInt256);
+                    resUInt256.Should().Be(resBigInt);
                 }
                 else
                 {
                     uint256a.Subtract(uint256b, out T res);
                     res.Convert(out resUInt256);
+                    resUInt256.Should().Be(resBigInt);
+
+                    uint256a.Subtract(uint256b, out uint256a);
+                    uint256a.Convert(out resUInt256);
+                    resUInt256.Should().Be(resBigInt);
                 }
-                resUInt256.Should().Be(resBigInt);
             }
             else
             {
@@ -168,6 +206,10 @@ namespace Nethermind.Int256.Test
                 {
                     uint256a.Subtract(uint256b, out T res);
                     res.Convert(out resUInt256);
+                    resUInt256.Should().Be(resBigInt);
+
+                    uint256a.Subtract(uint256b, out uint256a);
+                    uint256a.Convert(out resUInt256);
                     resUInt256.Should().Be(resBigInt);
                 }
             }
@@ -183,6 +225,11 @@ namespace Nethermind.Int256.Test
             T uint256b = convert(test.B);
             uint256a.Multiply(uint256b, out T res);
             res.Convert(out BigInteger resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
+
+            uint256a.Multiply(uint256b, out uint256a);
+            uint256a.Convert(out resUInt256);
 
             resUInt256.Should().Be(resBigInt);
         }
@@ -204,6 +251,11 @@ namespace Nethermind.Int256.Test
             res.Convert(out BigInteger resUInt256);
 
             resUInt256.Should().Be(resBigInt);
+
+            uint256a.MultiplyMod(uint256b, uint256m, out uint256a);
+            uint256a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
         }
 
         [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.TestCases))]
@@ -222,6 +274,11 @@ namespace Nethermind.Int256.Test
             res.Convert(out BigInteger resUInt256);
 
             resUInt256.Should().Be(resBigInt);
+
+            uint256a.Divide(in uint256b, out uint256a);
+            uint256a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
         }
         
         [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.TestCases))]
@@ -234,6 +291,11 @@ namespace Nethermind.Int256.Test
             T uint256b = convert(test.B);
             T.And(uint256a, uint256b, out T res);
             res.Convert(out BigInteger resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
+
+            T.And(uint256a, uint256b, out uint256a);
+            uint256a.Convert(out resUInt256);
 
             resUInt256.Should().Be(resBigInt);
         }
@@ -250,6 +312,11 @@ namespace Nethermind.Int256.Test
             res.Convert(out BigInteger resUInt256);
 
             resUInt256.Should().Be(resBigInt);
+
+            T.Or(uint256a, uint256b, out uint256a);
+            uint256a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
         }
 
         [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.TestCases))]
@@ -262,6 +329,11 @@ namespace Nethermind.Int256.Test
             T uint256b = convert(test.B);
             T.Xor(uint256a, uint256b, out T res);
             res.Convert(out BigInteger resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
+
+            T.Xor(uint256a, uint256b, out uint256a);
+            uint256a.Convert(out resUInt256);
 
             resUInt256.Should().Be(resBigInt);
         }
@@ -277,6 +349,11 @@ namespace Nethermind.Int256.Test
 
             uint256a.Exp(convertFromInt(test.n), out T res);
             res.Convert(out BigInteger resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
+
+            uint256a.Exp(convertFromInt(test.n), out uint256a);
+            uint256a.Convert(out resUInt256);
 
             resUInt256.Should().Be(resBigInt);
         }
@@ -300,6 +377,11 @@ namespace Nethermind.Int256.Test
             res.Convert(out BigInteger resUInt256);
 
             resUInt256.Should().Be(resBigInt);
+
+            uint256a.ExpMod(uint256b, uint256m, out uint256a);
+            uint256a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
         }
 
         [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.ShiftTestCases))]
@@ -318,6 +400,11 @@ namespace Nethermind.Int256.Test
             res.Convert(out BigInteger resUInt256);
 
             resUInt256.Should().Be(resBigInt);
+
+            uint256a.LeftShift(test.n, out uint256a);
+            uint256a.Convert(out resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
         }
 
         [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.ShiftTestCases))]
@@ -334,6 +421,11 @@ namespace Nethermind.Int256.Test
             T uint256a = convert(test.A);
             uint256a.RightShift(test.n, out T res);
             res.Convert(out BigInteger resUInt256);
+
+            resUInt256.Should().Be(resBigInt);
+
+            uint256a.RightShift(test.n, out uint256a);
+            uint256a.Convert(out resUInt256);
 
             resUInt256.Should().Be(resBigInt);
         }
@@ -358,6 +450,10 @@ namespace Nethermind.Int256.Test
             T uint256 = convert(test);
             T.Not(uint256, out T res);
             res.Convert(out BigInteger resUInt256);
+            resUInt256.Should().Be(resBigInt);
+
+            T.Not(in uint256, out uint256);
+            uint256.Convert(out resUInt256);
             resUInt256.Should().Be(resBigInt);
         }
 

--- a/src/Nethermind.Int256.Test/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Test/UInt256Tests.cs
@@ -565,5 +565,32 @@ namespace Nethermind.Int256.Test
                 catch (Exception e) when (e.GetType() == expectedException) { }
             }
         }
+
+        [TestCaseSource(typeof(Convertibles), nameof(Convertibles.TestCasesConvertFrom))]
+        public void ConvertFrom(Type type, BigInteger bigIntValue)
+        {
+            UInt256 ConvertToUInt256(Type type, BigInteger number) =>
+                type switch
+                {
+                    var t when type == typeof(byte) => (UInt256)(byte)number,
+                    var t when type == typeof(sbyte) => (UInt256)(sbyte)number,
+                    var t when type == typeof(short) => (UInt256)(short)number,
+                    var t when type == typeof(ushort) => (UInt256)(ushort)number,
+                    var t when type == typeof(int) => (UInt256)(int)number,
+                    var t when type == typeof(uint) => (UInt256)(uint)number,
+                    var t when type == typeof(long) => (UInt256)(long)number,
+                    var t when type == typeof(ulong) => (UInt256)(ulong)number,
+                    var t when type == typeof(float) => (UInt256)(float)number,
+                    var t when type == typeof(double) => (UInt256)(double)number,
+                    var t when type == typeof(decimal) => (UInt256)(decimal)number,
+                    var t when type == typeof(BigInteger) => (UInt256)(BigInteger)number,
+                    _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+                };
+
+            UInt256 res = ConvertToUInt256(type, bigIntValue);
+            res.Convert(out BigInteger resUInt256);
+
+            resUInt256.Should().BeEquivalentTo(bigIntValue);
+        }
     }
 }

--- a/src/Nethermind.Int256/Int256.cs
+++ b/src/Nethermind.Int256/Int256.cs
@@ -177,9 +177,9 @@ namespace Nethermind.Int256
                 b.Neg(out bv);
             }
             UInt256.Multiply(av._value, bv._value, out UInt256 ures);
-            res = new Int256(ures);
             int aSign = a.Sign;
             int bSign = b.Sign;
+            res = new Int256(ures);
             if ((aSign < 0 && bSign < 0) || (aSign >= 0 && bSign >= 0))
             {
                 return;

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -221,17 +221,14 @@ namespace Nethermind.Int256
                 a = -a;
             }
 
-            if (a <= ulong.MaxValue)
+            // don't use (a <= ulong.MaxValue) - this will result in different output on Mac and linux
+            if (a < ulong.MaxValue)
             {
                 ulong cu0 = (ulong)a;
                 ulong cu1 = 0;
                 ulong cu2 = 0;
                 ulong cu3 = 0;
                 c = new UInt256(cu0, cu1, cu2, cu3);
-
-                // fix difference with BigInteger
-                if (a == ulong.MaxValue)
-                    c.Add(1, out c);
             }
             else
             {

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -933,7 +933,7 @@ namespace Nethermind.Int256
 
         public void Subtract(in UInt256 b, out UInt256 res) => Subtract(this, b, out res);
 
-        public static void SubtractMod(in UInt256 a, in UInt256 b, in UInt256 m, out UInt256 res)
+        public static void SubtractMod(UInt256 a, in UInt256 b, in UInt256 m, out UInt256 res)
         {
             if (SubtractUnderflow(a, b, out res))
             {
@@ -1024,24 +1024,23 @@ namespace Nethermind.Int256
             result = new UInt256(res);
         }
 
-        public static void Exp(in UInt256 b, in UInt256 e, out UInt256 result)
+        public static void Exp(UInt256 b, in UInt256 e, out UInt256 result)
         {
             result = One;
-            UInt256 bs = b;
             int len = e.BitLen;
             for (int i = 0; i < len; i++)
             {
                 if (e.Bit(i))
                 {
-                    Multiply(result, bs, out result);
+                    Multiply(result, b, out result);
                 }
-                bs.Squared(out bs);
+                b.Squared(out b);
             }
         }
 
         public void Exp(in UInt256 exp, out UInt256 res) => Exp(this, exp, out res);
 
-        public static void ExpMod(in UInt256 b, in UInt256 e, in UInt256 m, out UInt256 result)
+        public static void ExpMod(UInt256 b, in UInt256 e, in UInt256 m, out UInt256 result)
         {
             if (m.IsOne)
             {
@@ -1049,15 +1048,14 @@ namespace Nethermind.Int256
                 return;
             }
             result = One;
-            UInt256 bs = b;
             int len = e.BitLen;
             for (int i = 0; i < len; i++)
             {
                 if (e.Bit(i))
                 {
-                    MultiplyMod(result, bs, m, out result);
+                    MultiplyMod(result, b, m, out result);
                 }
-                MultiplyMod(bs, bs, m, out bs);
+                MultiplyMod(b, b, m, out b);
             }
         }
 
@@ -1193,9 +1191,10 @@ namespace Nethermind.Int256
             // At this point, we know
             // x/y ; x > y > 0
 
-            res = default; // initialize with zeros
             const int length = 4;
-            Udivrem(ref Unsafe.As<UInt256, ulong>(ref res), ref Unsafe.As<UInt256, ulong>(ref Unsafe.AsRef(in x)), length, y, out UInt256 _);
+            UInt256 quot = default;
+            Udivrem(ref Unsafe.As<UInt256, ulong>(ref quot), ref Unsafe.As<UInt256, ulong>(ref Unsafe.AsRef(in x)), length, y, out UInt256 _);
+            res = quot;
         }
 
         public void Divide(in UInt256 a, out UInt256 res) => Divide(this, a, out res);
@@ -1278,8 +1277,7 @@ namespace Nethermind.Int256
                 }
             }
 
-            res = Zero;
-            ulong z0 = res.u0, z1 = res.u1, z2 = res.u2, z3 = res.u3;
+            ulong z0 = 0, z1 = 0, z2 = 0, z3 = 0;
             ulong a = 0, b = 0;
             // Big swaps first
             if (n > 192)

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1372,8 +1372,7 @@ namespace Nethermind.Int256
                 }
             }
 
-            res = Zero;
-            ulong z0 = res.u0, z1 = res.u1, z2 = res.u2, z3 = res.u3;
+            ulong z0 = 0, z1 = 0, z2 = 0, z3 = 0;
             ulong a = 0, b = 0;
             // Big swaps first
             if (n > 192)

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -228,6 +228,10 @@ namespace Nethermind.Int256
                 ulong cu2 = 0;
                 ulong cu3 = 0;
                 c = new UInt256(cu0, cu1, cu2, cu3);
+
+                // fix difference with BigInteger
+                if (a == ulong.MaxValue)
+                    c.Add(1, out c);
             }
             else
             {


### PR DESCRIPTION
fixes #32 