### PR TITLE
Automated parsabilety of hex numbers

### DIFF
--- a/src/Nethermind.Int256.Test/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Test/UInt256Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;
@@ -468,6 +468,14 @@ namespace Nethermind.Int256.Test
                 }
                 catch (Exception e) when (e.GetType() == expectedException) { }
             }
+        }
+        [Test]
+        public virtual void ParseLongNumber()
+        {
+            string hexValueWith66Zeroes = "0x" + new string('0', 66);
+            BigInteger bigIntWith66Zeroes = BigInteger.Parse(hexValueWith66Zeroes.Substring(2), NumberStyles.HexNumber);
+            var UintParsedValue = UInt256.Parse(hexValueWith66Zeroes);
+            Assert.AreEqual((UInt256)bigIntWith66Zeroes, UintParsedValue);
         }
     }
 }

--- a/src/Nethermind.Int256.Test/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Test/UInt256Tests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Binary;
 using System.Globalization;
 using System.Numerics;
@@ -1882,9 +1882,11 @@ namespace Nethermind.Int256
 
         public static UInt256 Parse(in ReadOnlySpan<char> value, NumberStyles numberStyles) => !TryParse(value, numberStyles, CultureInfo.InvariantCulture, out UInt256 c) ? throw new FormatException() : c;
 
-        public static bool TryParse(string value, out UInt256 result) => TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+        public static bool TryParse(string value, out UInt256 result) => TryParse(value.AsSpan(), out result);
 
-        public static bool TryParse(ReadOnlySpan<char> value, out UInt256 result) => TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+        public static bool TryParse(ReadOnlySpan<char> value, out UInt256 result) => value.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+            ? TryParse(value.Slice(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out result)
+            : TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
 
         public static bool TryParse(string value, NumberStyles style, IFormatProvider provider, out UInt256 result) => TryParse(value.AsSpan(), style, provider, out result);
 


### PR DESCRIPTION
We are fixing issue #34 by providing automated understanding to parser if the string to be parsed is hex or not.