### PR TITLE
Vectorized Multiply (on Avx512)

### DIFF
--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -89,8 +89,8 @@ namespace Nethermind.Int256.Benchmark
         public (int, Int256) D;
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class AddUnsigned : UnsignedTwoParamBenchmarkBase
     {
@@ -108,8 +108,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class AddSigned : SignedTwoParamBenchmarkBase
     {
@@ -127,8 +127,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class SubtractUnsigned : UnsignedTwoParamBenchmarkBase
     {
@@ -146,8 +146,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class SubtractSigned : SignedTwoParamBenchmarkBase
     {
@@ -165,8 +165,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class AddModUnsinged : UnsignedThreeParamBenchmarkBase
     {
@@ -184,8 +184,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class AddModSinged : SignedThreeParamBenchmarkBase
     {
@@ -203,8 +203,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class SubtractModUnsinged : UnsignedThreeParamBenchmarkBase
     {
@@ -222,8 +222,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class SubtractModSigned : SignedThreeParamBenchmarkBase
     {
@@ -241,8 +241,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class MultiplyUnsigned : UnsignedTwoParamBenchmarkBase
     {
@@ -260,8 +260,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class MultiplySigned : SignedTwoParamBenchmarkBase
     {
@@ -279,8 +279,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class MultiplyModUnsigned : UnsignedThreeParamBenchmarkBase
     {
@@ -298,8 +298,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class MultiplyModSigned : SignedThreeParamBenchmarkBase
     {
@@ -317,8 +317,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class DivideUnsigned : UnsignedTwoParamBenchmarkBase
     {
@@ -336,8 +336,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class DivideSigned : SignedTwoParamBenchmarkBase
     {
@@ -355,8 +355,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class ExpUnsigned : UnsignedIntTwoParamBenchmarkBase
     {
@@ -374,8 +374,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class ExpSigned : SignedIntTwoParamBenchmarkBase
     {
@@ -393,8 +393,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class ExpModUnsigned : UnsignedThreeParamBenchmarkBase
     {
@@ -412,8 +412,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class ExpModSigned : SignedBenchmarkBase
     {
@@ -440,8 +440,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class LeftShiftUnsigned : UnsignedIntTwoParamBenchmarkBase
     {
@@ -459,8 +459,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class LeftShiftSigned : SignedIntTwoParamBenchmarkBase
     {
@@ -478,8 +478,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class RightShiftUnsigned : UnsignedIntTwoParamBenchmarkBase
     {
@@ -497,8 +497,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class RightShiftSigned : SignedIntTwoParamBenchmarkBase
     {
@@ -516,8 +516,8 @@ namespace Nethermind.Int256.Benchmark
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-    [NoIntrinsicsJob(RuntimeMoniker.Net70)]
+    [SimpleJob(RuntimeMoniker.Net90, baseline: true)]
+    [NoIntrinsicsJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser]
     public class IsZeroOne
     {

--- a/src/Nethermind.Int256.Benchmark/NoIntrinsicsJobAttribute.cs
+++ b/src/Nethermind.Int256.Benchmark/NoIntrinsicsJobAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
@@ -116,6 +116,8 @@ namespace Nethermind.Int256.Benchmark
                     return CoreRuntime.Core70;
                 case RuntimeMoniker.Net80:
                     return CoreRuntime.Core80;
+                case RuntimeMoniker.Net90:
+                    return CoreRuntime.Core90;
                 case RuntimeMoniker.Mono:
                     return MonoRuntime.Default;
                 case RuntimeMoniker.NativeAot60:

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1199,14 +1199,9 @@ namespace Nethermind.Int256
                 // Normalize the overflow mask: shift each 64-bit lane right by 63 bits.
                 // This converts a full mask (0xFFFFFFFFFFFFFFFF) to 1, leaving lanes with no overflow as 0.
                 overflowMask = Sse2.ShiftRightLogical(overflowMask, 63);
-
-                // Promote the carry from the lower lane (element 0) into the upper lane.
-                // First, swap the two 64-bit lanes so that the lower lane's carry moves to the higher lane.
-                Vector128<ulong> swappedCarry = Sse2.Shuffle(overflowMask.AsDouble(), overflowMask.AsDouble(), 0x1).AsUInt64();
-
-                // Next, clear the (now swapped) lower lane by blending with a zero vector.
-                // The immediate mask 0x1 indicates that lane 0 should come from the zero vector and lane 1 remains unchanged.
-                Vector128<ulong> promotedCarry = Sse41.Blend(swappedCarry.AsDouble(), Vector128<double>.Zero, 0x1).AsUInt64();
+                // Next, clear the (now swapped) lower lane by shuffle with a zero vector.
+                // The immediate mask 0x0 indicates that lane 0 should come from the zero vector and lane 1 from overflow.
+                Vector128<ulong> promotedCarry = Sse2.Shuffle(Vector128<double>.Zero, overflowMask.AsDouble(), 0).AsUInt64();
 
                 // Add the propagated carry to the sum.
                 return Sse2.Add(sum, promotedCarry);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1059,22 +1059,28 @@ namespace Nethermind.Int256
 
                 // --- Package each 128-bit partial product into a UInt256 (with proper shifting) ---
 
-                // Group with no shift.
-                UInt256 part0 = new UInt256(P00_lo, P00_hi, 0, 0);
+                UInt256 intermediate;
+                {
+                    // Group with no shift.
+                    UInt256 part0 = new UInt256(P00_lo, P00_hi, 0, 0);
 
-                // Group shifted left by 64 bits.
-                UInt256 part64a = new UInt256(0, P01_lo, P01_hi, 0);
-                UInt256 part64b = new UInt256(0, P10_lo, P10_hi, 0);
-                UInt256 sum64;
-                AddImpl(part64a, part64b, out sum64);
-
-                // Group shifted left by 128 bits.
-                UInt256 part128a = new UInt256(0, 0, P02_lo, P02_hi);
-                UInt256 part128b = new UInt256(0, 0, P11_lo, P11_hi);
-                UInt256 part128c = new UInt256(0, 0, P20_lo, P20_hi);
-                UInt256 sum128, temp256;
-                AddImpl(part128a, part128b, out temp256);
-                AddImpl(temp256, part128c, out sum128);
+                    // Group shifted left by 64 bits.
+                    UInt256 part64a = new UInt256(0, P01_lo, P01_hi, 0);
+                    UInt256 part64b = new UInt256(0, P10_lo, P10_hi, 0);
+                    UInt256 sum64;
+                    AddImpl(part64a, part64b, out sum64);
+                    AddImpl(part0, sum64, out intermediate);
+                }
+                {
+                    // Group shifted left by 128 bits.
+                    UInt256 part128a = new UInt256(0, 0, P02_lo, P02_hi);
+                    UInt256 part128b = new UInt256(0, 0, P11_lo, P11_hi);
+                    UInt256 part128c = new UInt256(0, 0, P20_lo, P20_hi);
+                    UInt256 sum128, temp256;
+                    AddImpl(part128a, part128b, out temp256);
+                    AddImpl(temp256, part128c, out sum128);
+                    AddImpl(intermediate, sum128, out intermediate);
+                }
 
 
                 // Group 2: 2 products
@@ -1091,9 +1097,6 @@ namespace Nethermind.Int256
                 UInt256 part192256 = new UInt256(0, 0, 0, (P03_lo + P12_lo + P21_lo + P30_lo));
 
                 // --- Sum all the partial products using the proven UInt256 adder (AddImpl) ---
-                UInt256 intermediate;
-                AddImpl(part0, sum64, out intermediate);
-                AddImpl(intermediate, sum128, out intermediate);
                 AddImpl(intermediate, part192256, out res);
             }
         }

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1003,6 +1003,7 @@ namespace Nethermind.Int256
         /// <param name="x">The first 256‑bit unsigned integer.</param>
         /// <param name="y">The second 256‑bit unsigned integer.</param>
         /// <param name="res">When this method returns, contains the 256‑bit product of x and y.</param>
+        [SkipLocalsInit]
         public static void Multiply(in UInt256 x, in UInt256 y, out UInt256 res)
         {
             // If both inputs fit in 64 bits, use a simple multiplication routine.

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1132,12 +1132,10 @@ namespace Nethermind.Int256
 
             // 9. Group 3 cross‑terms:
             // Multiply the high limbs of x (x.u2, x.u3) with the low limbs of y (y.u1, y.u0) in reversed order.
-            Vector128<ulong> xHigh = Vector128.Create(x.u2, x.u3);
-            Vector128<ulong> yLow = Vector128.Create(y.u1, y.u0);
             Vector128<ulong> finalProdLow = Avx512DQ.VL.MultiplyLow(xHigh, yLow);
 
             // Add in the extra lower parts from the upper half of lowerPartial.
-            Vector128<ulong> extraLow = Avx2.ExtractVector128(lowerPartial.GetUpper(), 1);
+            Vector128<ulong> extraLow = Avx512F.ExtractVector128(lowerPartial, 3);
             finalProdLow = Sse2.Add(finalProdLow, extraLow);
             // Perform a horizontal sum so that both lanes contain the same result.
             Vector128<ulong> swappedFinal = Sse2.UnpackLow(finalProdLow, finalProdLow);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1194,7 +1194,7 @@ namespace Nethermind.Int256
                 overflowMask = Sse2.ShiftRightLogical(overflowMask, 63);
                 // Next, clear the (now swapped) lower lane by shuffle with a zero vector.
                 // The immediate mask 0x0 indicates that lane 0 should come from the zero vector and lane 1 from overflow.
-                Vector128<ulong> promotedCarry = Sse2.Shuffle(Vector128<double>.Zero, overflowMask.AsDouble(), 0).AsUInt64();
+                Vector128<ulong> promotedCarry = Sse2.UnpackLow(Vector128<ulong>.Zero, overflowMask);
 
                 // Add the propagated carry to the sum.
                 return Sse2.Add(sum, promotedCarry);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1010,7 +1010,7 @@ namespace Nethermind.Int256
                 Unsafe.AsRef(in res.u1) = high;
                 return;
             }
-            
+
             if (!Avx512F.IsSupported || !Avx512DQ.IsSupported)
             {
                 ref ulong rx = ref Unsafe.As<UInt256, ulong>(ref Unsafe.AsRef(in x));
@@ -1034,189 +1034,241 @@ namespace Nethermind.Int256
             }
             else
             {
-                // Load the 256‐bit inputs into 256‐bit vector registers.
+                // 1. Load the 256‐bit inputs into 256‐bit vector registers.
                 Vector256<ulong> aVector = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in x));
                 Vector256<ulong> bVector = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in y));
 
-                // Rearrange the 64‐bit limbs of each input into 512‐bit vectors.
-                // The chosen permutations align the limbs so that later 64‐bit multiplications yield the correct cross‐products.
-                Vector512<ulong> rearrangedA = Vector512.Create(
-                    Avx2.Permute4x64(aVector, 16),  // Lower part permutation for A
-                    Avx2.Permute4x64(aVector, 73)); // Upper part permutation for A
+                // 2. Rearrange the 64‐bit limbs into 512‐bit vectors.
+                Vector256<ulong> aPerm0 = Avx2.Permute4x64(aVector, 16);
+                Vector256<ulong> aPerm1 = Avx2.Permute4x64(aVector, 73);
+                Vector512<ulong> rearrangedA = Vector512.Create(aPerm0, aPerm1);
 
-                Vector512<ulong> rearrangedB = Vector512.Create(
-                    Avx2.Permute4x64(bVector, 132), // Lower part permutation for B
-                    Avx2.Permute4x64(bVector, 177)); // Upper part permutation for B
+                Vector256<ulong> bPerm0 = Avx2.Permute4x64(bVector, 132);
+                Vector256<ulong> bPerm1 = Avx2.Permute4x64(bVector, 177);
+                Vector512<ulong> rearrangedB = Vector512.Create(bPerm0, bPerm1);
 
-                // Multiply the corresponding 64‐bit limbs of the rearranged inputs.
-                // Each multiplication yields a 128‐bit product split into a low and high 64‐bit part.
+                // 3. Multiply the corresponding 64‐bit limbs.
                 Mul64Vector(rearrangedA, rearrangedB, out Vector512<ulong> partialLo, out Vector512<ulong> partialHi);
 
-                // --- Extract Partial Products from the First Group ---
-                //
-                // The following partial products (with both low and high parts) result from the 64‐bit multiplications.
-                // They are named to indicate their source position in the multiplication grid.
-                ulong prod00_Lo = partialLo.GetElement(0), prod00_Hi = partialHi.GetElement(0);
-                ulong prod01_Lo = partialLo.GetElement(1), prod01_Hi = partialHi.GetElement(1);
-                ulong prod10_Lo = partialLo.GetElement(2), prod10_Hi = partialHi.GetElement(2);
-                ulong prod02_Lo = partialLo.GetElement(3), prod02_Hi = partialHi.GetElement(3);
-                ulong prod11_Lo = partialLo.GetElement(4), prod11_Hi = partialHi.GetElement(4);
-                ulong prod20_Lo = partialLo.GetElement(5), prod20_Hi = partialHi.GetElement(5);
-                ulong prod03_Lo = partialLo.GetElement(6); // Only lower 64‐bits produced.
-                ulong prod12_Lo = partialLo.GetElement(7); // Only lower 64‐bits produced.
+                // 4. Rearrange the six “group‑1” products (prod00, prod01, prod10, prod02, prod11, prod20)
+                //    into 128‑bit quantities. (Here we use the AVX‑512 “extract 128‑bit” function to get two adjacent 64‑bit lanes.)
+                //    – Products 0 and 1 come from index 0:
+                Vector128<ulong> pair01Lo = Avx512F.ExtractVector128(partialLo, 0); // lanes 0–1: prod00_lo, prod01_lo
+                Vector128<ulong> pair01Hi = Avx512F.ExtractVector128(partialHi, 0); // lanes 0–1: prod00_hi, prod01_hi
+                // Unpack lower (lane0) and upper (lane1) to form product0 and product1:
+                Vector128<ulong> prod0 = Sse2.UnpackLow(pair01Lo, pair01Hi);  // prod00 = {lo, hi}
+                Vector128<ulong> prod1 = Sse2.UnpackHigh(pair01Lo, pair01Hi); // prod01 = {lo, hi}
 
-                // --- Combine Lower-Group Partial Products into an Intermediate 256-bit Result ---
-                //
-                // The cross-terms prod01 and prod10 contribute to the middle limbs of the full product.
-                // First, add these two 128‐bit values (each stored as two 64‐bit limbs) with proper carry propagation.
-                Vector128<ulong> crossTermA = Vector128.Create(prod01_Lo, prod01_Hi);
-                Vector128<ulong> crossTermB = Vector128.Create(prod10_Lo, prod10_Hi);
-                Vector128<ulong> crossSum = Vector128AddWithCarry(crossTermA, crossTermB);
+                // – Products 2 and 3 come from index 1:
+                Vector128<ulong> pair23Lo = Avx512F.ExtractVector128(partialLo, 1); // lanes 2–3: prod10_lo, prod02_lo
+                Vector128<ulong> pair23Hi = Avx512F.ExtractVector128(partialHi, 1); // lanes 2–3: prod10_hi, prod02_hi
+                Vector128<ulong> prod2 = Sse2.UnpackLow(pair23Lo, pair23Hi);  // prod10
+                Vector128<ulong> prod3 = Sse2.UnpackHigh(pair23Lo, pair23Hi); // prod02
 
-                // The lower 64‐bit lane of the cross‐sum will be added to the high part of prod00.
-                ulong crossLowPart = crossSum.GetElement(0);
-                ulong combinedProd00_Hi = prod00_Hi + crossLowPart;
+                // – Products 4 and 5 come from index 2:
+                Vector128<ulong> pair45Lo = Avx512F.ExtractVector128(partialLo, 2); // lanes 4–5: prod11_lo, prod20_lo
+                Vector128<ulong> pair45Hi = Avx512F.ExtractVector128(partialHi, 2); // lanes 4–5: prod11_hi, prod20_hi
+                Vector128<ulong> prod4 = Sse2.UnpackLow(pair45Lo, pair45Hi);  // prod11
+                Vector128<ulong> prod5 = Sse2.UnpackHigh(pair45Lo, pair45Hi); // prod20
 
-                // Build the initial 256‐bit intermediate result from the lower-group products:
-                // • Limb 0: prod00_Lo (lowest 64 bits of prod00)
-                // • Limb 1: combinedProd00_Hi (prod00_Hi plus the low cross‐term)
-                // • Limb 2: The high lane of the cross‐sum plus a carry if the addition in limb 1 overflowed.
-                // • Limb 3: A final carry from the cross‐term addition (if prod01_Hi exceeds crossSum’s high lane).
-                Vector256<ulong> intermediateResult = Vector256.Create(
-                    prod00_Lo,
-                    combinedProd00_Hi,
-                    crossSum.GetElement(1) + (prod00_Hi > combinedProd00_Hi ? 1ul : 0ul),
-                    (prod01_Hi > crossSum.GetElement(1) ? 1ul : 0ul));
+                // 5. Group‑1 “cross‑term” addition:
+                //    crossSum = prod01 + prod10 (i.e. add the 128‑bit numbers prod1 and prod2)
+                Vector128<ulong> crossSum = Add128(prod1, prod2);
 
-                // --- Add Contributions from the Upper Group Partial Products ---
-                //
-                // The products prod02 and prod11 form one 128‐bit group.
-                Vector128<ulong> group2_A = Vector128.Create(prod02_Lo, prod02_Hi);
-                Vector128<ulong> group2_B = Vector128.Create(prod11_Lo, prod11_Hi);
-                Vector128<ulong> group2Sum = Vector128AddWithCarry(group2_A, group2_B);
+                // 6. Add the low half of crossSum (i.e. its lower 64 bits) to prod00’s high limb.
+                //    Instead of extracting a scalar, we broadcast the lower 64 bits to a vector.
+                //    (Assume BroadcastLower128 returns a copy with both lanes equal to element0.)
+                Vector128<ulong> csLow = BroadcastLower128(crossSum);
+                // Create a mask to add only to the high lane: mask = {0, ulong.MaxValue}
+                Vector128<ulong> highMask = Vector128.Create(0ul, ulong.MaxValue);
+                Vector128<ulong> addMask = Sse2.And(csLow, highMask);
+                Vector128<ulong> prod0Updated = Sse2.Add(prod0, addMask);
 
-                // Include the contribution from prod20 into the group sum.
-                Vector128<ulong> group2_C = Vector128.Create(prod20_Lo, prod20_Hi);
-                Vector128<ulong> totalGroup2 = Vector128AddWithCarry(group2Sum, group2_C);
+                // Now, compute the “carry” from that addition. (Again, we must compute a one‐bit flag.)
+                uint carryFlag = (uint)Sse2.MoveMask(Avx512F.VL.CompareLessThan(
+                    ExtractHighLimb(prod0Updated), // compare updated high limb...
+                    ExtractHighLimb(prod0)         // ...with the original high limb
+                    ).AsByte()) & 1;
+                // Add the carry to the high half of crossSum. (Broadcast the carry into a 128‑bit vector.)
+                Vector128<ulong> csHigh = BroadcastUpper128(crossSum);
+                Vector128<ulong> limb2 = Sse2.Add(csHigh, Vector128.CreateScalar((ulong)carryFlag));
 
-                // These 128 bits (two 64-bit lanes) belong in the upper half (limbs 2 and 3) of the intermediate result.
-                // Retrieve the current upper 128 bits of the intermediate result and add the group2 sum.
-                Vector128<ulong> currentUpperHalf = intermediateResult.GetUpper();
-                Vector128<ulong> newUpperHalf = Vector128AddWithCarry(currentUpperHalf, totalGroup2);
+                // And form limb3 from a comparison of prod01’s high limb with crossSum’s high:
+                uint limb3 = (uint)(Sse2.MoveMask(Avx512F.VL.CompareGreaterThan(
+                    ExtractHighLimb(prod1), csHigh).AsByte()) & 1);
+                Vector128<ulong> limb3Vec = Vector128.CreateScalar((ulong)limb3);
 
-                // Update the intermediate result with the new upper half (the lower half remains unchanged).
-                intermediateResult = Vector256.Create(
-                    intermediateResult.GetLower(),
-                    newUpperHalf);
+                // 7. Build the 256‑bit “intermediate” result from group‑1:
+                //    Lower 128 bits = prod00 (with updated high limb)
+                //    Upper 128 bits = (limb2, limb3) packed into a 128‑bit vector.
+                Vector128<ulong> lowerIntermediate = prod0Updated;
+                // Pack limb2 into the lower half and limb3 into the upper half.
+                Vector128<ulong> upperIntermediate = Sse2.UnpackLow(limb2, limb3Vec);
+                Vector256<ulong> intermediateResult = Vector256.Create(lowerIntermediate, upperIntermediate);
 
-                // --- Process and Add the Final (Group 3) Contributions ---
-                //
-                // For the remaining contribution, multiply selected limbs from the inputs.
-                // Here, the upper 128 bits of x and the lower 128 bits of y (in reversed order) are multiplied.
+                // 8. Process group‑2: (prod02, prod11, prod20)
+                Vector128<ulong> group2Sum = Add128(prod3, prod4);
+                Vector128<ulong> totalGroup2 = Add128(group2Sum, prod5);
+                // Add totalGroup2 into the current upper 128 bits of intermediateResult.
+                Vector128<ulong> currentUpper = GetUpper(intermediateResult);
+                Vector128<ulong> newUpper = Add128(currentUpper, totalGroup2);
+                intermediateResult = WithUpper(intermediateResult, newUpper);
+
+                // 9. Process group‑3:
+                //    Multiply “aHigh” and “bLow” (with the proper reversed order) then add in the remaining lower parts.
                 Vector128<ulong> aHigh = Vector128.Create(x.u2, x.u3);
                 Vector128<ulong> bLow = Vector128.Create(y.u1, y.u0);
+                // Use the AVX512DQ MultiplyLow intrinsic (which multiplies 64‑bit integers and returns the low 64 bits)
                 Vector128<ulong> finalProdLow = Avx512DQ.VL.MultiplyLow(aHigh, bLow);
 
-                // Add the remaining lower parts from prod03 and prod12.
-                finalProdLow = Sse2.Add(finalProdLow, Vector128.Create(prod03_Lo, prod12_Lo));
+                // Extract from partialLo the two lower parts for prod03 and prod12.
+                // With partialLo logically split into Lower (lanes 0–3) and Upper (lanes 4–7),
+                // lanes 6 and 7 are in the Upper half; extracting the second 128‐bit portion of Upper gives us these lanes.
+                Vector128<ulong> prod6 = Avx2.ExtractVector128(partialLo.GetUpper(), 1);
+                // Extract from index 3 the two lower‐parts from prod03 and prod12 (which we stored in “prod6”):
+                // (Note: prod6 already holds both lower parts.)
+                finalProdLow = Sse2.Add(finalProdLow, prod6);
+                // Now perform a horizontal add so that the two 64‑bit lanes collapse to a single 64‑bit value.
+                Vector128<ulong> horizontalSum = HorizontalAdd(finalProdLow);
+                // Add the horizontal sum (broadcast into the high lane) to the most–significant limb of intermediateResult.
+                Vector128<ulong> upperTemp = GetUpper(intermediateResult);
+                Vector128<ulong> hsBroadcast = Sse2.And(BroadcastLower128(horizontalSum), highMask);
+                Vector128<ulong> newUpperTemp = Sse2.Add(upperTemp, hsBroadcast);
+                intermediateResult = WithUpper(intermediateResult, newUpperTemp);
 
-                // Perform a horizontal add on finalProdLow to collapse its two 64‐bit lanes into one sum.
-                // (This is done by shuffling the 64-bit lanes using a double-precision view and then adding them.)
-                Vector128<ulong> shuffledULong = Sse2.Shuffle(finalProdLow.AsDouble(), finalProdLow.AsDouble(), 0x1).AsUInt64();
-                Vector128<ulong> horizontalSum = Sse2.Add(finalProdLow, shuffledULong);
-
-                // Add the horizontal sum (the final contribution) to the most-significant limb (limb 3) of the intermediate result.
-                ulong updatedMostSignificant = intermediateResult.GetElement(3) + horizontalSum.GetElement(0);
-
-                // Write the final 256-bit product, updating limb 3 with the new value.
+                // 10. Write out the final 256‑bit result.
                 Unsafe.SkipInit(out res);
-                Unsafe.As<UInt256, Vector256<ulong>>(ref res) =
-                    intermediateResult.WithElement(3, updatedMostSignificant);
+                Unsafe.As<UInt256, Vector256<ulong>>(ref res) = intermediateResult;
 
+                static Vector128<ulong> HorizontalAdd(Vector128<ulong> vec)
+                {
+                    // Reinterpret the 64-bit integer vector as a vector of two doubles.
+                    // Then use _mm_shuffle_pd (exposed as Sse2.Shuffle for doubles) to swap the two lanes.
+                    Vector128<ulong> swapped = Sse2.Shuffle(vec.AsDouble(), vec.AsDouble(), 0x1).AsUInt64();
+
+                    // Add the original vector and the swapped vector.
+                    // This results in a vector where both lanes equal (vec[0] + vec[1]).
+                    return Sse2.Add(vec, swapped);
+                }
+
+                // Helpers that mimic “GetUpper” and “WithUpper” on a 256‑bit vector.
+                // (You might implement these as extension methods on Vector256<T>.)
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static Vector128<ulong> GetUpper(Vector256<ulong> vec)
+                {
+                    // For example, using Avx2.ExtractVector128:
+                    return Avx2.ExtractVector128(vec, 1);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static Vector256<ulong> WithUpper(Vector256<ulong> vec, Vector128<ulong> upper)
+                {
+                    // Replace the upper 128 bits of vec with upper.
+                    return Avx2.InsertVector128(vec, upper, 1);
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static Vector128<ulong> ExtractHighLimb(Vector128<ulong> vec)
+                {
+                    // Reinterpret the 64-bit vector as 32-bit elements, shuffle to replicate the upper 64-bit limb,
+                    // then reinterpret back as 64-bit.
+                    return Sse2.Shuffle(vec.AsUInt32(), 0xEE).AsUInt64();
+                }
+
+                // Helpers to “broadcast” the lower or upper 64‐bit lane of a Vector128<ulong>.
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static Vector128<ulong> BroadcastLower128(Vector128<ulong> vec)
+                {
+                    // Replicate element0 to both lanes.
+                    return Sse2.Shuffle(vec.AsDouble(), vec.AsDouble(), 0).AsUInt64();
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static Vector128<ulong> BroadcastUpper128(Vector128<ulong> vec)
+                {
+                    // Replicate element1 to both lanes.
+                    return Sse2.Shuffle(vec.AsDouble(), vec.AsDouble(), 3).AsUInt64(); // 0xFF means both lanes come from the original element1
+                }
+                /// <summary>
+                /// Adds two 128-bit unsigned integers while propagating an overflow (carry) from the lower 64-bit lane to the higher lane.
+                /// Each 128-bit integer is represented as a <see cref="Vector128{ulong}"/>, with element 0 holding the lower 64 bits
+                /// and element 1 holding the higher 64 bits.
+                /// </summary>
+                /// <param name="operand1">The first 128-bit unsigned integer operand.</param>
+                /// <param name="operand2">The second 128-bit unsigned integer operand.</param>
+                /// <returns>
+                /// A <see cref="Vector128{ulong}"/> representing the sum of the two operands, with any carry from the lower lane added
+                /// into the higher lane.
+                /// </returns>
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static Vector128<ulong> Add128(Vector128<ulong> left, Vector128<ulong> right)
+                {
+                    // Perform a lane-wise addition of the two operands.
+                    Vector128<ulong> sum = Sse2.Add(left, right);
+
+                    // For unsigned addition, an overflow in a lane occurs if the result is less than one of the operands.
+                    // Comparing 'sum' with 'operand1' produces a mask where each 64-bit lane is all ones if an overflow occurred, or zero otherwise.
+                    Vector128<ulong> overflowMask = Avx512F.VL.CompareLessThan(sum, left);
+
+                    // Normalize the overflow mask: shift each 64-bit lane right by 63 bits.
+                    // This converts a full mask (0xFFFFFFFFFFFFFFFF) to 1, leaving lanes with no overflow as 0.
+                    overflowMask = Sse2.ShiftRightLogical(overflowMask, 63);
+
+                    // Promote the carry from the lower lane (element 0) into the upper lane.
+                    // First, swap the two 64-bit lanes so that the lower lane's carry moves to the higher lane.
+                    Vector128<ulong> swappedCarry = Sse2.Shuffle(overflowMask.AsDouble(), overflowMask.AsDouble(), 0x1).AsUInt64();
+
+                    // Next, clear the (now swapped) lower lane by blending with a zero vector.
+                    // The immediate mask 0x1 indicates that lane 0 should come from the zero vector and lane 1 remains unchanged.
+                    Vector128<ulong> promotedCarry = Sse41.Blend(swappedCarry.AsDouble(), Vector128<double>.Zero, 0x1).AsUInt64();
+
+                    // Add the propagated carry to the sum.
+                    return Sse2.Add(sum, promotedCarry);
+                }
             }
 
-            /// <summary>
-            /// Adds two 128-bit unsigned integers while propagating an overflow (carry) from the lower 64-bit lane to the higher lane.
-            /// Each 128-bit integer is represented as a <see cref="Vector128{ulong}"/>, with element 0 holding the lower 64 bits
-            /// and element 1 holding the higher 64 bits.
-            /// </summary>
-            /// <param name="operand1">The first 128-bit unsigned integer operand.</param>
-            /// <param name="operand2">The second 128-bit unsigned integer operand.</param>
-            /// <returns>
-            /// A <see cref="Vector128{ulong}"/> representing the sum of the two operands, with any carry from the lower lane added
-            /// into the higher lane.
-            /// </returns>
+            // Vectorized 64x64 multiply: given vectors 'a' and 'b' (each 8 lanes),
+            // computes per lane:
+            //   product = a * b = (hi, lo)
+            // using the splitting method since there is no MultiplyHigh intrinsic.
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static Vector128<ulong> Vector128AddWithCarry(Vector128<ulong> left, Vector128<ulong> right)
+            static void Mul64Vector(Vector512<ulong> a, Vector512<ulong> b,
+                                              out Vector512<ulong> lo, out Vector512<ulong> hi)
             {
-                // Perform a lane-wise addition of the two operands.
-                Vector128<ulong> sum = Sse2.Add(left, right);
+                // Mask for the lower 32 bits.
+                Vector512<ulong> mask32 = Vector512.Create(0xFFFFFFFFUL);
 
-                // For unsigned addition, an overflow in a lane occurs if the result is less than one of the operands.
-                // Comparing 'sum' with 'operand1' produces a mask where each 64-bit lane is all ones if an overflow occurred, or zero otherwise.
-                Vector128<ulong> overflowMask = Avx512F.VL.CompareLessThan(sum, left);
+                // Split each 64-bit operand into 32-bit halves:
+                // a0 = lower 32 bits, a1 = upper 32 bits
+                Vector512<ulong> a0 = Avx512F.And(a, mask32);
+                Vector512<ulong> a1 = Avx512F.ShiftRightLogical(a, 32);
+                Vector512<ulong> b0 = Avx512F.And(b, mask32);
+                Vector512<ulong> b1 = Avx512F.ShiftRightLogical(b, 32);
 
-                // Normalize the overflow mask: shift each 64-bit lane right by 63 bits.
-                // This converts a full mask (0xFFFFFFFFFFFFFFFF) to 1, leaving lanes with no overflow as 0.
-                overflowMask = Sse2.ShiftRightLogical(overflowMask, 63);
+                // Compute the four 32x32 partial products.
+                // Each multiplication here is on 32-bit values, so the result fits in 64 bits.
+                Vector512<ulong> u0 = Avx512DQ.MultiplyLow(a0, b0); // a0 * b0
+                Vector512<ulong> u1 = Avx512DQ.MultiplyLow(a0, b1); // a0 * b1
+                Vector512<ulong> u2 = Avx512DQ.MultiplyLow(a1, b0); // a1 * b0
+                Vector512<ulong> u3 = Avx512DQ.MultiplyLow(a1, b1); // a1 * b1
 
-                // Promote the carry from the lower lane (element 0) into the upper lane.
-                // First, swap the two 64-bit lanes so that the lower lane's carry moves to the higher lane.
-                Vector128<ulong> swappedCarry = Sse2.Shuffle(overflowMask.AsDouble(), overflowMask.AsDouble(), 0x1).AsUInt64();
+                // Now, compute t = (u0 >> 32) + (u1 & mask32) + (u2 & mask32)
+                Vector512<ulong> u0_hi = Avx512F.ShiftRightLogical(u0, 32);
+                Vector512<ulong> u1_lo = Avx512F.And(u1, mask32);
+                Vector512<ulong> u2_lo = Avx512F.And(u2, mask32);
+                Vector512<ulong> t = Avx512F.Add(Avx512F.Add(u0_hi, u1_lo), u2_lo);
 
-                // Next, clear the (now swapped) lower lane by blending with a zero vector.
-                // The immediate mask 0x1 indicates that lane 0 should come from the zero vector and lane 1 remains unchanged.
-                Vector128<ulong> promotedCarry = Sse41.Blend(swappedCarry.AsDouble(), Vector128<double>.Zero, 0x1).AsUInt64();
+                // The extra carry: c = t >> 32.
+                Vector512<ulong> c = Avx512F.ShiftRightLogical(t, 32);
 
-                // Add the propagated carry to the sum.
-                return Sse2.Add(sum, promotedCarry);
+                // Now, assemble the lower 64 bits:
+                // low part of u0 is u0 & mask32; low 32 bits of t are (t & mask32) shifted left 32.
+                Vector512<ulong> u0_lo = Avx512F.And(u0, mask32);
+                Vector512<ulong> t_lo = Avx512F.And(t, mask32);
+                lo = Avx512F.Or(u0_lo, Avx512F.ShiftLeftLogical(t_lo, 32));
+
+                // The high 64 bits are: u3 + (u1 >> 32) + (u2 >> 32) + c.
+                Vector512<ulong> u1_hi = Avx512F.ShiftRightLogical(u1, 32);
+                Vector512<ulong> u2_hi = Avx512F.ShiftRightLogical(u2, 32);
+                hi = Avx512F.Add(Avx512F.Add(Avx512F.Add(u3, u1_hi), u2_hi), c);
             }
-        }
-        
-        // Vectorized 64x64 multiply: given vectors 'a' and 'b' (each 8 lanes),
-        // computes per lane:
-        //   product = a * b = (hi, lo)
-        // using the splitting method since there is no MultiplyHigh intrinsic.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Mul64Vector(Vector512<ulong> a, Vector512<ulong> b,
-                                          out Vector512<ulong> lo, out Vector512<ulong> hi)
-        {
-            // Mask for the lower 32 bits.
-            Vector512<ulong> mask32 = Vector512.Create(0xFFFFFFFFUL);
-
-            // Split each 64-bit operand into 32-bit halves:
-            // a0 = lower 32 bits, a1 = upper 32 bits
-            Vector512<ulong> a0 = Avx512F.And(a, mask32);
-            Vector512<ulong> a1 = Avx512F.ShiftRightLogical(a, 32);
-            Vector512<ulong> b0 = Avx512F.And(b, mask32);
-            Vector512<ulong> b1 = Avx512F.ShiftRightLogical(b, 32);
-
-            // Compute the four 32x32 partial products.
-            // Each multiplication here is on 32-bit values, so the result fits in 64 bits.
-            Vector512<ulong> u0 = Avx512DQ.MultiplyLow(a0, b0); // a0 * b0
-            Vector512<ulong> u1 = Avx512DQ.MultiplyLow(a0, b1); // a0 * b1
-            Vector512<ulong> u2 = Avx512DQ.MultiplyLow(a1, b0); // a1 * b0
-            Vector512<ulong> u3 = Avx512DQ.MultiplyLow(a1, b1); // a1 * b1
-
-            // Now, compute t = (u0 >> 32) + (u1 & mask32) + (u2 & mask32)
-            Vector512<ulong> u0_hi = Avx512F.ShiftRightLogical(u0, 32);
-            Vector512<ulong> u1_lo = Avx512F.And(u1, mask32);
-            Vector512<ulong> u2_lo = Avx512F.And(u2, mask32);
-            Vector512<ulong> t = Avx512F.Add(Avx512F.Add(u0_hi, u1_lo), u2_lo);
-
-            // The extra carry: c = t >> 32.
-            Vector512<ulong> c = Avx512F.ShiftRightLogical(t, 32);
-
-            // Now, assemble the lower 64 bits:
-            // low part of u0 is u0 & mask32; low 32 bits of t are (t & mask32) shifted left 32.
-            Vector512<ulong> u0_lo = Avx512F.And(u0, mask32);
-            Vector512<ulong> t_lo = Avx512F.And(t, mask32);
-            lo = Avx512F.Or(u0_lo, Avx512F.ShiftLeftLogical(t_lo, 32));
-
-            // The high 64 bits are: u3 + (u1 >> 32) + (u2 >> 32) + c.
-            Vector512<ulong> u1_hi = Avx512F.ShiftRightLogical(u1, 32);
-            Vector512<ulong> u2_hi = Avx512F.ShiftRightLogical(u2, 32);
-            hi = Avx512F.Add(Avx512F.Add(Avx512F.Add(u3, u1_hi), u2_hi), c);
         }
 
         public void Multiply(in UInt256 a, out UInt256 res) => Multiply(this, a, out res);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1136,8 +1136,9 @@ namespace Nethermind.Int256
             // Now perform a horizontal add so that the two 64‑bit lanes collapse to a single 64‑bit value.
             Vector128<ulong> horizontalSum = HorizontalAdd(finalProdLow);
             // Add the horizontal sum (broadcast into the high lane) to the most–significant limb of intermediateResult.
-            Vector128<ulong> highMask = Vector128.Create(0ul, ulong.MaxValue);
-            intermediateResult = Avx2.Add(intermediateResult, Vector256.Create(default, Sse2.And(horizontalSum, highMask)));
+            // 2. Use a shuffle with a zero vector to directly form { 0, horizontalSum[0] }
+            Vector128<ulong> high = Sse2.Shuffle(Vector128<double>.Zero, horizontalSum.AsDouble(), 0).AsUInt64();
+            intermediateResult = Avx2.Add(intermediateResult, Vector256.Create(Vector128<ulong>.Zero, high));
 
             // 10. Write out the final 256‑bit result.
             Unsafe.SkipInit(out res);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1117,7 +1117,7 @@ namespace Nethermind.Int256
             // Add totalGroup2 into the current upper 128 bits of intermediateResult.
             Vector128<ulong> currentUpper = intermediateResult.GetUpper();
             Vector128<ulong> newUpper = Add128(currentUpper, totalGroup2);
-            intermediateResult = WithUpper(intermediateResult, newUpper);
+            intermediateResult = Avx2.InsertVector128(intermediateResult, newUpper, 1);
 
             // 9. Process group‑3:
             //    Multiply x23 and y10 (with the proper reversed order) then add in the remaining lower parts.
@@ -1147,13 +1147,6 @@ namespace Nethermind.Int256
             // 10. Write out the final 256‑bit result.
             Unsafe.SkipInit(out res);
             Unsafe.As<UInt256, Vector256<ulong>>(ref res) = intermediateResult;
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static Vector256<ulong> WithUpper(Vector256<ulong> vec, Vector128<ulong> upper)
-            {
-                // Replace the upper 128 bits of vec with upper.
-                return Avx2.InsertVector128(vec, upper, 1);
-            }
 
             /// <summary>
             /// Adds two 128-bit unsigned integers while propagating an overflow (carry) from the lower 64-bit lane to the higher lane.

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1034,19 +1034,19 @@ namespace Nethermind.Int256
             }
             else
             {
-
+                // Vectorized branch using AVX-512.
                 // Unpack the four 64-bit limbs (little-endian: u0 is least-significant)
                 ulong a0 = x.u0, a1 = x.u1, a2 = x.u2, a3 = x.u3;
                 ulong b0 = y.u0, b1 = y.u1, b2 = y.u2, b3 = y.u3;
 
-                // --- Compute the 10 64x64–bit products using our vectorized method ---
+                // --- Compute the 10 64x64–bit partial products using our vectorized method ---
 
                 // Group 1: 8 products
                 Vector512<ulong> vecA1 = Vector512.Create(a0, a0, a1, a0, a1, a2, a0, a1);
                 Vector512<ulong> vecB1 = Vector512.Create(b0, b1, b0, b2, b1, b0, b3, b2);
                 Mul64Vector(vecA1, vecB1, out Vector512<ulong> lo1, out Vector512<ulong> hi1);
 
-                // Extract products from group1
+                // Extract products from group 1.
                 ulong P00_lo = lo1.GetElement(0), P00_hi = hi1.GetElement(0);
                 ulong P01_lo = lo1.GetElement(1), P01_hi = hi1.GetElement(1);
                 ulong P10_lo = lo1.GetElement(2), P10_hi = hi1.GetElement(2);
@@ -1056,51 +1056,44 @@ namespace Nethermind.Int256
                 ulong P03_lo = lo1.GetElement(6), P03_hi = hi1.GetElement(6);
                 ulong P12_lo = lo1.GetElement(7), P12_hi = hi1.GetElement(7);
 
-                // Group 2: 2 products
-                Vector512<ulong> vecA2 = Vector512.Create(a2, a3, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL);
-                Vector512<ulong> vecB2 = Vector512.Create(b1, b0, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL);
-                Mul64Vector(vecA2, vecB2, out Vector512<ulong> lo2, out Vector512<ulong> hi2);
-                ulong P21_lo = lo2.GetElement(0); // P21_hi is not needed (contributes only above 256 bits)
-                ulong P30_lo = lo2.GetElement(1); // Likewise for P30_hi
-
                 // --- Package each 128-bit partial product into a UInt256 (with proper shifting) ---
-                // (Recall: a 128–bit product is given as (lo, hi), where lo is the lower 64 bits and hi the upper 64 bits.)
 
-                // P00 (no shift)
+                // Group with no shift.
                 UInt256 part0 = new UInt256(P00_lo, P00_hi, 0, 0);
 
-                // P01 and P10 (each shifted left by 64 bits)
+                // Group shifted left by 64 bits.
                 UInt256 part64a = new UInt256(0, P01_lo, P01_hi, 0);
                 UInt256 part64b = new UInt256(0, P10_lo, P10_hi, 0);
                 UInt256 sum64;
                 AddImpl(part64a, part64b, out sum64);
 
-                // P02, P11 and P20 (each shifted left by 128 bits)
+                // Group shifted left by 128 bits.
                 UInt256 part128a = new UInt256(0, 0, P02_lo, P02_hi);
                 UInt256 part128b = new UInt256(0, 0, P11_lo, P11_hi);
                 UInt256 part128c = new UInt256(0, 0, P20_lo, P20_hi);
-                UInt256 sum128, temp;
-                AddImpl(part128a, part128b, out temp);
-                AddImpl(temp, part128c, out sum128);
+                UInt256 sum128, temp256;
+                AddImpl(part128a, part128b, out temp256);
+                AddImpl(temp256, part128c, out sum128);
 
-                // P03, P12, P21 and P30 (shifted left by 192 bits – note only the low 64 bits matter)
-                UInt256 part192a = new UInt256(0, 0, 0, P03_lo);
-                UInt256 part192b = new UInt256(0, 0, 0, P12_lo);
-                UInt256 part192c = new UInt256(0, 0, 0, P21_lo);
-                UInt256 part192d = new UInt256(0, 0, 0, P30_lo);
-                UInt256 sum192;
-                AddImpl(part192a, part192b, out temp);
-                AddImpl(temp, part192c, out temp);
-                AddImpl(temp, part192d, out sum192);
 
-                // --- Sum all the partial products using AddImpl ---
+                // Group 2: 2 products
+                Vector512<ulong> vecA2 = Vector512.Create(a2, a3, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL);
+                Vector512<ulong> vecB2 = Vector512.Create(b1, b0, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL);
+                Mul64Vector(vecA2, vecB2, out Vector512<ulong> lo2, out Vector512<ulong> hi2);
+                ulong P21_lo = lo2.GetElement(0); // Only lower 64 bits matter.
+                ulong P30_lo = lo2.GetElement(1);
+
+                // Group shifted left by 192 bits – only the lower 64 bits contribute.
+                // Any carry is discarded, so just use normal addition.
+                UInt256 part192256 = new UInt256(0, 0, 0, (P03_lo + P12_lo + P21_lo + P30_lo));
+
+                // --- Sum all the partial products using the proven UInt256 adder (AddImpl) ---
                 UInt256 intermediate;
                 AddImpl(part0, sum64, out intermediate);
                 AddImpl(intermediate, sum128, out intermediate);
-                AddImpl(intermediate, sum192, out res);
+                AddImpl(intermediate, part192256, out res);
             }
         }
-
         
         // Vectorized 64x64 multiply: given vectors 'a' and 'b' (each 8 lanes),
         // computes per lane:

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1092,6 +1092,8 @@ namespace Nethermind.Int256
             Vector128<ulong> product4 = Avx512F.ExtractVector128(productLow, 2);
             Vector128<ulong> product5 = Avx512F.ExtractVector128(productHi, 2);
 
+            Vector128<ulong> xHigh = Vector128.Create(x.u2, x.u3);
+            Vector128<ulong> yLow = Vector128.Create(y.u1, y.u0);
             // 5. Group 1 cross‑term addition:
             // Compute crossSum = product1 + product2 (as 128‑bit numbers).
             Vector128<ulong> crossSum = Add128(product1, product2);
@@ -1118,7 +1120,6 @@ namespace Nethermind.Int256
 
             // Pack limb2 (low) and limb3 (high) to form the new upper half.
             Vector128<ulong> upperIntermediate = Sse2.UnpackLow(limb2, limb3);
-
 
             // 8. Group 2 combination:
             // Sum product3, product4, and product5.

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1090,13 +1090,13 @@ namespace Nethermind.Int256
             Vector128<ulong> prod0Updated = Sse2.Add(prod0, addMask);
 
             // Now, compute the “carry” from that addition. (Again, we must compute a one‐bit flag.)
-            uint carryFlag = (uint)Sse2.MoveMask(Avx512F.VL.CompareLessThan(
+            Vector128<ulong> carryFlag = Sse2.ShiftRightLogical(Avx512F.VL.CompareLessThan(
                 Sse2.UnpackHigh(prod0Updated, prod0Updated), // compare updated high limb...
                 Sse2.UnpackHigh(prod0, prod0)         // ...with the original high limb
-                ).AsByte()) & 1;
+                ), 63);
             // Add the carry to the high half of crossSum. (Broadcast the carry into a 128‑bit vector.)
             Vector128<ulong> csHigh = Sse2.UnpackHigh(crossSum, crossSum);
-            Vector128<ulong> limb2 = Sse2.Add(csHigh, Vector128.CreateScalar((ulong)carryFlag));
+            Vector128<ulong> limb2 = Sse2.Add(csHigh, carryFlag);
 
             // And form limb3 from a comparison of prod01’s high limb with crossSum’s high:
             // Shift right each lane by 63 bits, so that 0 becomes 0 and 0xFFFFFFFFFFFFFFFF becomes 1.

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1086,7 +1086,7 @@ namespace Nethermind.Int256
             // 6. Add the low half of crossSum (i.e. its lower 64 bits) to prod00’s high limb.
             //    Instead of extracting a scalar, we broadcast the lower 64 bits to a vector.
             //    (Assume BroadcastLower128 returns a copy with both lanes equal to element0.)
-            Vector128<ulong> addMask = Sse2.Shuffle(Vector128<double>.Zero, crossSum.AsDouble(), 0).AsUInt64();
+            Vector128<ulong> addMask = Sse2.UnpackLow(Vector128<ulong>.Zero, crossSum);
             Vector128<ulong> prod0Updated = Sse2.Add(prod0, addMask);
 
             // Now, compute the “carry” from that addition. (Again, we must compute a one‐bit flag.)

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1128,7 +1128,6 @@ namespace Nethermind.Int256
             Vector128<ulong> newUpper = Add128(upperIntermediate, totalGroup2);
             // 7. Build the intermediate 256‑bit result.
             // Lower 128 bits come from the updated product0; upper 128 bits come from (limb2, limb3).
-            Vector256<ulong> intermediateResult = Vector256.Create(updatedProduct0, newUpper);
 
             // 9. Group 3 cross‑terms:
             // Multiply the high limbs of x (x.u2, x.u3) with the low limbs of y (y.u1, y.u0) in reversed order.
@@ -1144,7 +1143,8 @@ namespace Nethermind.Int256
             Vector128<ulong> horizontalSum = Sse2.Add(finalProdLow, swappedFinal);
             // Add the horizontal sum (broadcast into the high lane) to the most‑significant limb.
             Vector128<ulong> highCarry = Sse2.UnpackHigh(Vector128<ulong>.Zero, horizontalSum);
-            intermediateResult = Avx2.Add(intermediateResult, Vector256.Create(Vector128<ulong>.Zero, highCarry));
+            newUpper = Sse2.Add(newUpper, highCarry);
+            Vector256<ulong> intermediateResult = Vector256.Create(updatedProduct0, newUpper);
 
             // 10. Write out the final 256‑bit result.
             Unsafe.SkipInit(out res);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1119,18 +1119,16 @@ namespace Nethermind.Int256
             // Pack limb2 (low) and limb3 (high) to form the new upper half.
             Vector128<ulong> upperIntermediate = Sse2.UnpackLow(limb2, limb3);
 
-            // 7. Build the intermediate 256‑bit result.
-            // Lower 128 bits come from the updated product0; upper 128 bits come from (limb2, limb3).
-            Vector256<ulong> intermediateResult = Vector256.Create(updatedProduct0, upperIntermediate);
 
             // 8. Group 2 combination:
             // Sum product3, product4, and product5.
             Vector128<ulong> group2Sum = Add128(product3, product4);
             Vector128<ulong> totalGroup2 = Add128(group2Sum, product5);
             // Add this total into the upper 128 bits of the intermediate result.
-            Vector128<ulong> currentUpper = intermediateResult.GetUpper();
-            Vector128<ulong> newUpper = Add128(currentUpper, totalGroup2);
-            intermediateResult = Avx2.InsertVector128(intermediateResult, newUpper, 1);
+            Vector128<ulong> newUpper = Add128(upperIntermediate, totalGroup2);
+            // 7. Build the intermediate 256‑bit result.
+            // Lower 128 bits come from the updated product0; upper 128 bits come from (limb2, limb3).
+            Vector256<ulong> intermediateResult = Vector256.Create(updatedProduct0, newUpper);
 
             // 9. Group 3 cross‑terms:
             // Multiply the high limbs of x (x.u2, x.u3) with the low limbs of y (y.u1, y.u0) in reversed order.

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1076,24 +1076,21 @@ namespace Nethermind.Int256
                                                      Avx512F.ShiftRightLogical(prodHL, 32)),
                                                  Avx512F.ShiftRightLogical(termT, 32));
 
+            Vector512<ulong> productLow = Avx512F.UnpackLow(lowerPartial, higherPartial);
+            Vector512<ulong> productHi = Avx512F.UnpackHigh(lowerPartial, higherPartial);
+
             // 4. Unpack the 512‑bit partial results into six 128‑bit values.
             // Group 1 (products 0 and 1):
-            Vector128<ulong> pair01Lo = Avx512F.ExtractVector128(lowerPartial, 0); // lanes 0–1: product0 (low), product1 (low)
-            Vector128<ulong> pair01Hi = Avx512F.ExtractVector128(higherPartial, 0); // lanes 0–1: product0 (high), product1 (high)
-            Vector128<ulong> product0 = Sse2.UnpackLow(pair01Lo, pair01Hi);  // product0 = { low, high }
-            Vector128<ulong> product1 = Sse2.UnpackHigh(pair01Lo, pair01Hi); // product1 = { low, high }
+            Vector128<ulong> product0 = Avx512F.ExtractVector128(productLow, 0);
+            Vector128<ulong> product1 = Avx512F.ExtractVector128(productHi, 0);
 
             // Group 2 (products 2 and 3):
-            Vector128<ulong> pair23Lo = Avx512F.ExtractVector128(lowerPartial, 1); // lanes 2–3
-            Vector128<ulong> pair23Hi = Avx512F.ExtractVector128(higherPartial, 1); // lanes 2–3
-            Vector128<ulong> product2 = Sse2.UnpackLow(pair23Lo, pair23Hi);
-            Vector128<ulong> product3 = Sse2.UnpackHigh(pair23Lo, pair23Hi);
+            Vector128<ulong> product2 = Avx512F.ExtractVector128(productLow, 1);
+            Vector128<ulong> product3 = Avx512F.ExtractVector128(productHi, 1);
 
             // Group 3 (products 4 and 5):
-            Vector128<ulong> pair45Lo = Avx512F.ExtractVector128(lowerPartial, 2); // lanes 4–5
-            Vector128<ulong> pair45Hi = Avx512F.ExtractVector128(higherPartial, 2); // lanes 4–5
-            Vector128<ulong> product4 = Sse2.UnpackLow(pair45Lo, pair45Hi);
-            Vector128<ulong> product5 = Sse2.UnpackHigh(pair45Lo, pair45Hi);
+            Vector128<ulong> product4 = Avx512F.ExtractVector128(productLow, 2);
+            Vector128<ulong> product5 = Avx512F.ExtractVector128(productHi, 2);
 
             // 5. Group 1 cross‑term addition:
             // Compute crossSum = product1 + product2 (as 128‑bit numbers).

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1095,7 +1095,7 @@ namespace Nethermind.Int256
                 Sse2.UnpackHigh(prod0, prod0)         // ...with the original high limb
                 ).AsByte()) & 1;
             // Add the carry to the high half of crossSum. (Broadcast the carry into a 128‑bit vector.)
-            Vector128<ulong> csHigh = BroadcastUpper128(crossSum);
+            Vector128<ulong> csHigh = Sse2.UnpackHigh(crossSum, crossSum);
             Vector128<ulong> limb2 = Sse2.Add(csHigh, Vector128.CreateScalar((ulong)carryFlag));
 
             // And form limb3 from a comparison of prod01’s high limb with crossSum’s high:
@@ -1155,12 +1155,6 @@ namespace Nethermind.Int256
                 return Avx2.InsertVector128(vec, upper, 1);
             }
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static Vector128<ulong> BroadcastUpper128(Vector128<ulong> vec)
-            {
-                // Replicate element1 to both lanes.
-                return Sse2.Shuffle(vec.AsDouble(), vec.AsDouble(), 3).AsUInt64(); // 0xFF means both lanes come from the original element1
-            }
             /// <summary>
             /// Adds two 128-bit unsigned integers while propagating an overflow (carry) from the lower 64-bit lane to the higher lane.
             /// Each 128-bit integer is represented as a <see cref="Vector128{ulong}"/>, with element 0 holding the lower 64 bits

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1003,7 +1003,6 @@ namespace Nethermind.Int256
         /// <param name="x">The first 256‑bit unsigned integer.</param>
         /// <param name="y">The second 256‑bit unsigned integer.</param>
         /// <param name="res">When this method returns, contains the 256‑bit product of x and y.</param>
-        [SkipLocalsInit]
         public static void Multiply(in UInt256 x, in UInt256 y, out UInt256 res)
         {
             // If both inputs fit in 64 bits, use a simple multiplication routine.
@@ -1042,17 +1041,18 @@ namespace Nethermind.Int256
             }
 
             // Step 1: load the inputs and prepare the mask constant.
-            Vector512<ulong> xPermute = Vector512.Create(0ul, 0, 1, 0, 1, 2, 0, 1);
-            Vector512<ulong> yPermute = Vector512.Create(0ul, 1, 0, 2, 1, 0, 3, 2);
-            Unsafe.SkipInit(out Vector512<ulong> vecX);
-            Unsafe.SkipInit(out Vector512<ulong> vecY);
-            vecX = Avx512F.InsertVector256(vecX, Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in x)), 0);
-            vecY = Avx512F.InsertVector256(vecY, Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in y)), 0);
+            Vector256<ulong> vecX = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in x));
+            Vector256<ulong> vecY = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in y));
             Vector512<ulong> mask32 = Vector512.Create(0xFFFFFFFFUL);
 
             // Step 2: permute x and y. These operations are independent.
-            Vector512<ulong> xRearranged = Avx512F.PermuteVar8x64(vecX, xPermute);
-            Vector512<ulong> yRearranged = Avx512F.PermuteVar8x64(vecY, yPermute);
+            Vector256<ulong> xPerm1 = Avx2.Permute4x64(vecX, 16);  // [ x0, x0, x1, x0 ]
+            Vector256<ulong> yPerm1 = Avx2.Permute4x64(vecY, 132); // [ y0, y1, y0, y2 ]
+            Vector256<ulong> xPerm2 = Avx2.Permute4x64(vecX, 73);  // [ x1, x2, x0, x1 ]
+            Vector256<ulong> yPerm2 = Avx2.Permute4x64(vecY, 177); // [ y1, y0, y3, y2 ]
+
+            Vector512<ulong> xRearranged = Vector512.Create(xPerm1, xPerm2);
+            Vector512<ulong> yRearranged = Vector512.Create(yPerm1, yPerm2);
 
             // Step 3: split each 64‑bit limb into its lower and upper 32‑bit parts.
             Vector512<ulong> xLowerParts = Avx512F.And(xRearranged, mask32);


### PR DESCRIPTION
~30% faster (current Scalar has vectorized Adds) on AMD Ryzen 9 7950X; x2.5 times faster than vanilla MULX

| Method           | Environment   | A                   | B                   | Mean     | Error    | StdDev   | Ratio |
|----------------- |-------------- |-------------------- |-------------------- |---------:|---------:|---------:|------:|
| Multiply_UInt256 | HWIntrinsic=0 | (619(...)658) [156] | (619(...)658) [156] | 21.44 ns | 0.359 ns | 0.369 ns |  1.79 |
| Multiply_UInt256 | Scalar        | (619(...)658) [156] | (619(...)658) [156] | 12.02 ns | 0.240 ns | 0.321 ns |  1.00 |
| Multiply_UInt256 | Avx512        | (619(...)658) [156] | (619(...)658) [156] |  8.56 ns | 0.126 ns | 0.118 ns |  0.71 |
|                  |               |                     |                     |          |          |          |       |
| Multiply_UInt256 | HWIntrinsic=0 | (619(...)658) [156] | (115(...)935) [160] | 21.64 ns | 0.442 ns | 0.491 ns |  1.84 |
| Multiply_UInt256 | Scalar        | (619(...)658) [156] | (115(...)935) [160] | 11.74 ns | 0.243 ns | 0.227 ns |  1.00 |
| Multiply_UInt256 | Avx512        | (619(...)658) [156] | (115(...)935) [160] |  8.65 ns | 0.150 ns | 0.140 ns |  0.74 |
|                  |               |                     |                     |          |          |          |       |
| Multiply_UInt256 | HWIntrinsic=0 | (115(...)935) [160] | (619(...)658) [156] | 21.81 ns | 0.453 ns | 0.589 ns |  1.83 |
| Multiply_UInt256 | Scalar        | (115(...)935) [160] | (619(...)658) [156] | 11.90 ns | 0.235 ns | 0.209 ns |  1.00 |
| Multiply_UInt256 | Avx512        | (115(...)935) [160] | (619(...)658) [156] |  8.48 ns | 0.139 ns | 0.124 ns |  0.71 |
|                  |               |                     |                     |          |          |          |       |
| Multiply_UInt256 | HWIntrinsic=0 | (115(...)935) [160] | (115(...)935) [160] | 21.95 ns | 0.444 ns | 0.416 ns |  1.80 |
| Multiply_UInt256 | Scalar        | (115(...)935) [160] | (115(...)935) [160] | 12.21 ns | 0.231 ns | 0.216 ns |  1.00 |
| Multiply_UInt256 | Avx512        | (115(...)935) [160] | (115(...)935) [160] |  8.58 ns | 0.155 ns | 0.145 ns |  0.70 |

Asm output

```asm
; Assembly listing for method Nethermind.Int256.UInt256:Multiply(byref,byref,byref) (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX512 - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 5 single block inlinees; 2 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       sub      rsp, 200
 
G_M000_IG02:                ;; offset=0x0007
       mov      rax, qword ptr [rcx+0x08]
       or       rax, qword ptr [rcx+0x10]
       or       rax, qword ptr [rcx+0x18]
       or       rax, qword ptr [rdx+0x08]
       or       rax, qword ptr [rdx+0x10]
       or       rax, qword ptr [rdx+0x18]
       je       G_M000_IG06
 
G_M000_IG03:                ;; offset=0x0025
       vmovups  zmm0, zmmword ptr [rsp+0x50]
       vinserti64x4 zmm0, zmm0, ymmword ptr [rcx], 0
       vmovups  zmm1, zmmword ptr [rsp+0x10]
       vinserti64x4 zmm1, zmm1, ymmword ptr [rdx], 0
       vmovups  zmm2, zmmword ptr [reloc @RWD00]
       vmovups  zmm3, zmmword ptr [reloc @RWD64]
       vpermq   zmm1, zmm3, zmm1
       vmovups  zmm3, zmmword ptr [reloc @RWD128]
       vpermq   zmm0, zmm3, zmm0
       vpandq   zmm3, zmm2, zmm0
       vpandq   zmm4, zmm2, zmm1
       vpsrlq   zmm1, zmm1, 32
       vpmullq  zmm5, zmm3, zmm4
       vpmullq  zmm3, zmm3, zmm1
       vpsrlq   zmm0, zmm0, 32
       vpmullq  zmm4, zmm0, zmm4
       vpmullq  zmm0, zmm0, zmm1
       vpandq   zmm1, zmm2, zmm3
       vpsrlq   zmm16, zmm5, 32
       vpaddq   zmm1, zmm1, zmm16
       vpandq   zmm16, zmm2, zmm4
       vpaddq   zmm1, zmm16, zmm1
       vpandq   zmm16, zmm2, zmm1
       vpsllq   zmm16, zmm16, 32
       vpternlogq zmm5, zmm16, zmm2, -20
       vpsrlq   zmm2, zmm3, 32
       vpaddq   zmm0, zmm2, zmm0
       vpsrlq   zmm2, zmm4, 32
       vpaddq   zmm0, zmm2, zmm0
       vpsrlq   zmm1, zmm1, 32
       vpaddq   zmm0, zmm1, zmm0
       vpunpcklqdq zmm1, zmm5, zmm0
       vextracti32x4 xmm2, zmm1, 0
       vpunpckhqdq zmm0, zmm5, zmm0
       vextracti32x4 xmm3, zmm0, 0
       vextracti32x4 xmm4, zmm1, 1
       vextracti32x4 xmm16, zmm0, 1
       vextracti32x4 xmm1, zmm1, 2
       vextracti32x4 xmm0, zmm0, 2
       vmovd    xmm17, qword ptr [rcx+0x10]
       vpinsrq  xmm17, xmm17, qword ptr [rcx+0x18], 1
       vmovd    xmm18, qword ptr [rdx+0x08]
       vpinsrq  xmm18, xmm18, qword ptr [rdx], 1
       vpaddq   xmm4, xmm3, xmm4
       vpcmpuq  k1, xmm4, xmm3, 1
       vpmovm2q xmm19, k1
       vpsrlq   xmm19, xmm19, 63
       vxorps   xmm20, xmm20, xmm20
       vpunpcklqdq xmm19, xmm20, xmm19
       vpaddq   xmm4, xmm19, xmm4
       vpunpcklqdq xmm19, xmm20, xmm4
       vpaddq   xmm19, xmm19, xmm2
       vpunpckhqdq xmm20, xmm19, xmm19
       vpunpckhqdq xmm2, xmm2, xmm2
       vpcmpuq  k1, xmm20, xmm2, 1
       vpmovm2q xmm2, k1
       vpsrlq   xmm2, xmm2, 63
       vpunpckhqdq xmm4, xmm4, xmm4
       vpunpckhqdq xmm3, xmm3, xmm3
       vpcmpuq  k1, xmm3, xmm4, 6
       vpmovm2q xmm3, k1
       vpsrlq   xmm3, xmm3, 63
       vpaddq   xmm1, xmm16, xmm1
       vpcmpuq  k1, xmm1, xmm16, 1
       vpmovm2q xmm16, k1
       vpsrlq   xmm16, xmm16, 63
 
G_M000_IG04:                ;; offset=0x01D8
       vxorps   xmm20, xmm20, xmm20
       vpunpcklqdq xmm16, xmm20, xmm16
       vpaddq   xmm1, xmm16, xmm1
       vpaddq   xmm0, xmm1, xmm0
       vpcmpuq  k1, xmm0, xmm1, 1
       vpmovm2q xmm1, k1
       vpsrlq   xmm1, xmm1, 63
       vpunpcklqdq xmm1, xmm20, xmm1
       vpaddq   xmm0, xmm1, xmm0
       vpaddq   xmm1, xmm4, xmm2
       vpunpcklqdq xmm1, xmm1, xmm3
       vpaddq   xmm0, xmm1, xmm0
       vpcmpuq  k1, xmm0, xmm1, 1
       vpmovm2q xmm1, k1
       vpsrlq   xmm1, xmm1, 63
       vpunpcklqdq xmm1, xmm20, xmm1
       vpaddq   xmm0, xmm1, xmm0
       vpmullq  xmm1, xmm17, xmm18
       vextracti32x4 xmm2, zmm5, 3
       vpaddq   xmm1, xmm2, xmm1
       vpunpcklqdq xmm2, xmm1, xmm1
       vpaddq   xmm1, xmm2, xmm1
       vpunpckhqdq xmm1, xmm20, xmm1
       vpaddq   xmm0, xmm1, xmm0
       vinserti32x4 ymm0, ymm19, xmm0, 1
       vmovups  ymmword ptr [r8], ymm0
 
G_M000_IG05:                ;; offset=0x0261
       vzeroupper 
       add      rsp, 200
       ret      
 
G_M000_IG06:                ;; offset=0x026C
       mov      bword ptr [rsp+0xD8], rdx
       mov      rdx, qword ptr [rcx]
       mov      rax, bword ptr [rsp+0xD8]
       mov      rax, qword ptr [rax]
       lea      rcx, [rsp+0x08]
       mulx     rax, r10, rax
       mov      qword ptr [rcx], r10
       mov      rcx, qword ptr [rsp+0x08]
       vxorps   ymm0, ymm0, ymm0
       vmovdqu  ymmword ptr [r8], ymm0
       mov      qword ptr [r8], rcx
       mov      qword ptr [r8+0x08], rax
 
G_M000_IG07:                ;; offset=0x02A4
       vzeroupper 
       add      rsp, 200
       ret      
 
RWD00  	dq	00000000FFFFFFFFh, 00000000FFFFFFFFh, 00000000FFFFFFFFh, 00000000FFFFFFFFh, 00000000FFFFFFFFh, 00000000FFFFFFFFh, 00000000FFFFFFFFh, 00000000FFFFFFFFh
RWD64  	dq	0000000000000000h, 0000000000000001h, 0000000000000000h, 0000000000000002h, 0000000000000001h, 0000000000000000h, 0000000000000003h, 0000000000000002h
RWD128 	dq	0000000000000000h, 0000000000000000h, 0000000000000001h, 0000000000000000h, 0000000000000001h, 0000000000000002h, 0000000000000000h, 0000000000000001h

; Total bytes of code 687
```