### PR TITLE
Use native ulong shifts when custom shift is not needed

### DIFF
--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -676,7 +676,7 @@ namespace Nethermind.Int256
         }
 
         // Udivrem divides u by d and produces both quotient and remainder.
-        // It assumes d is not zero.
+        // Throws if d is zero.
         // The quotient is stored in provided quot - len(u)-len(d)+1 words.
         // It loosely follows the Knuth's division algorithm (sometimes referenced as "schoolbook" division) using 64-bit words.
         // See Knuth, Volume 2, section 4.3.1, Algorithm D.

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -704,7 +704,7 @@ namespace Nethermind.Int256
             }
             else
             {
-                throw new DivideByZeroException();
+                ThrowDivideByZeroException("d == 0");
             }
 
             int uLen = 0;
@@ -1430,7 +1430,7 @@ namespace Nethermind.Int256
             const ulong mask32 = two32 - 1;
             if (y == 0)
             {
-                ThrowDivideByZeroException();
+                ThrowDivideByZeroException("y == 0");
             }
 
             if (y <= hi)
@@ -2223,7 +2223,7 @@ namespace Nethermind.Int256
         public ulong ToUInt64(IFormatProvider? provider) => System.Convert.ToUInt64(ToDecimal(provider), provider);
 
         [DoesNotReturn]
-        private static void ThrowDivideByZeroException() => throw new DivideByZeroException("y == 0");
+        private static void ThrowDivideByZeroException(string message) => throw new DivideByZeroException(message);
 
         [DoesNotReturn]
         private static void ThrowOverflowException(string message) => throw new OverflowException(message);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 using System.Runtime.Intrinsics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: InternalsVisibleTo("Nethermind.Int256.Test")]
@@ -663,12 +664,14 @@ namespace Nethermind.Int256
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong NativeLsh(ulong a, int n)
         {
+            Debug.Assert(n < 64);
             return a << n;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong NativeRsh(ulong a, int n)
         {
+            Debug.Assert(n < 64);
             return a >> n;
         }
 

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -725,7 +725,8 @@ namespace Nethermind.Int256
                     shift = LeadingZeros(d.u0);
                 }
             }
-            else
+
+            if (dLen == 0)
             {
                 ThrowDivideByZeroException();
             }

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -707,7 +707,7 @@ namespace Nethermind.Int256
             }
             else
             {
-                ThrowDivideByZeroException("d == 0");
+                ThrowDivideByZeroException();
             }
 
             int uLen = 0;
@@ -1433,7 +1433,7 @@ namespace Nethermind.Int256
             const ulong mask32 = two32 - 1;
             if (y == 0)
             {
-                ThrowDivideByZeroException("y == 0");
+                ThrowDivideByZeroException();
             }
 
             if (y <= hi)
@@ -2226,7 +2226,7 @@ namespace Nethermind.Int256
         public ulong ToUInt64(IFormatProvider? provider) => System.Convert.ToUInt64(ToDecimal(provider), provider);
 
         [DoesNotReturn]
-        private static void ThrowDivideByZeroException(string message) => throw new DivideByZeroException(message);
+        private static void ThrowDivideByZeroException() => throw new DivideByZeroException();
 
         [DoesNotReturn]
         private static void ThrowOverflowException(string message) => throw new OverflowException(message);


### PR DESCRIPTION
In some cases, we are using our `ulong` `Lsh` and `Rsh` implementations instead of the native ones. This would be necessary in the case that `n == 64`, since C# masks the shift amount by 64 and as such `a << 64 == a`, but we want `a << 64 == 0`.
However, it seems like in some of these cases in `UInt256` we can, in fact, consider some restrictions on the values of `n` and replace the custom with the native shift operations, avoiding some extra steps.

1. In `Udivrem`, `shift` is `LeadingZeroes(FirstNonZero(d.u[0], d.u[1], d.u[2], d.u[3]))`. So, we know this could only be 64 if all of them are zeroes. But in this case `d` would be zero which means a division by zero. `shift` can be zero though. This means shifting by `shift` can be native while by `64 - shift` would still require the custom shift.
2. In `Div64` it's a similar situation. `shift < 64` since `d` can only have 64 leading zeroes if it is zero, but `shift` can still be zero. This also means shifting by `shift` can be native while by `64 - shift` would still require the custom shift. 
3. In `Lsh(UInt256,...)` and `Rsh(UInt256,...)`, we know that, in the bit shift section at the end, `n` cannot be 64 as we have already done all the word shifts we could do before. We also know it can't be zero as we are returning early in the cases it's only 0-4 word shifts. So, since `n` is strictly in [1..63], this means we can replace all the shifts with native ones.

With a very simple benchmark this seems to have had a significant effect in `Lsh` performance, but requires better testing.
Whether these benefits justify the additional complexity is also an important point.

