### PR TITLE
Less branchy Udivrem

### DIFF
--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -675,11 +675,15 @@ namespace Nethermind.Int256
                 // Use the fact that u0, u1, u2, u3 can be loaded as a vector
                 Vector256<ulong> v = Vector256.LoadUnsafe(in d.u0);
 
-                // Check which is zero
+                // Check which ulongs are zero
                 var isZero = Vector256.IsZero(v);
 
-                // Use most significant bits, negation and masking with 4 bits to find the most significant set
-                dLen = 32 - BitOperations.LeadingZeroCount(~isZero.ExtractMostSignificantBits() & 0b1111);
+                const int ulongCount = 4;
+                const uint mask = (1 << ulongCount) - 1;
+
+                // The nth most significant bit is 1 if a nth ulong is 0. Negate and mask with 4 bits to find the most significant set.
+                var nonZeroUlongBits = ~isZero.ExtractMostSignificantBits() & mask;
+                dLen = 32 - BitOperations.LeadingZeroCount(nonZeroUlongBits);
                 shift = LeadingZeros(Unsafe.Add(ref Unsafe.AsRef(in d.u0), dLen - 1));
             }
             else

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -672,8 +672,13 @@ namespace Nethermind.Int256
 
             if (Vector256.IsHardwareAccelerated)
             {
+                // Use the fact that u0, u1, u2, u3 can be loaded as a vector
                 Vector256<ulong> v = Vector256.LoadUnsafe(in d.u0);
+
+                // Check which is zero
                 var isZero = Vector256.IsZero(v);
+
+                // Use most significant bits, negation and masking with 4 bits to find the most significant set
                 dLen = 32 - BitOperations.LeadingZeroCount(~isZero.ExtractMostSignificantBits() & 0b1111);
                 shift = LeadingZeros(Unsafe.Add(ref Unsafe.AsRef(in d.u0), dLen - 1));
             }


### PR DESCRIPTION
This PR replaces the first set of `ifs` with a vector based approach. The resulting method is ~50 bytes lighter, has 4 branches less (58 instead of 62) and is ~1-2 % faster (I don't believe such small numbers and would love to see your checks for it).

### Benchmarks

Using `AddMod_UInt256` for benchmarks

<details>

#### before

| Method         | EnvironmentVariables       | C                   | A                   | B                   | Mean      | Error     | StdDev    | Ratio | RatioSD | Code Size | Allocated | Alloc Ratio |
|--------------- |--------------------------- |-------------------- |-------------------- |-------------------- |----------:|----------:|----------:|------:|--------:|----------:|----------:|------------:|
| **AddMod_UInt256** | **Empty**                      | **(619(...)658) [156]** | **(619(...)658) [156]** | **(619(...)658) [156]** | **46.182 ns** | **0.8056 ns** | **0.7142 ns** |  **1.00** |    **0.02** |   **4,483 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (619(...)658) [156] | (619(...)658) [156] | (619(...)658) [156] | 81.911 ns | 0.4257 ns | 0.3774 ns |  1.77 |    0.03 |   6,280 B |         - |          NA |
|                |                            |                     |                     |                     |           |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(619(...)658) [156]** | **(619(...)658) [156]** | **(115(...)935) [160]** | **56.944 ns** | **0.6850 ns** | **0.6408 ns** |  **1.00** |    **0.02** |   **4,057 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (619(...)658) [156] | (619(...)658) [156] | (115(...)935) [160] | 97.714 ns | 0.6452 ns | 0.5388 ns |  1.72 |    0.02 |   5,124 B |         - |          NA |
|                |                            |                     |                     |                     |           |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(619(...)658) [156]** | **(115(...)935) [160]** | **(619(...)658) [156]** | **57.312 ns** | **0.4676 ns** | **0.4145 ns** |  **1.00** |    **0.01** |   **4,057 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (619(...)658) [156] | (115(...)935) [160] | (619(...)658) [156] | 97.625 ns | 0.7901 ns | 0.7390 ns |  1.70 |    0.02 |   5,124 B |         - |          NA |
|                |                            |                     |                     |                     |           |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(619(...)658) [156]** | **(115(...)935) [160]** | **(115(...)935) [160]** | **57.197 ns** | **0.5008 ns** | **0.4439 ns** |  **1.00** |    **0.01** |   **4,057 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (619(...)658) [156] | (115(...)935) [160] | (115(...)935) [160] | 97.634 ns | 0.5893 ns | 0.5512 ns |  1.71 |    0.02 |   5,124 B |         - |          NA |
|                |                            |                     |                     |                     |           |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(115(...)935) [160]** | **(619(...)658) [156]** | **(619(...)658) [156]** |  **6.200 ns** | **0.1172 ns** | **0.1096 ns** |  **1.00** |    **0.02** |     **986 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (115(...)935) [160] | (619(...)658) [156] | (619(...)658) [156] | 19.617 ns | 0.3267 ns | 0.3056 ns |  3.17 |    0.07 |   2,280 B |         - |          NA |
|                |                            |                     |                     |                     |           |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(115(...)935) [160]** | **(619(...)658) [156]** | **(115(...)935) [160]** | **56.108 ns** | **0.4235 ns** | **0.3754 ns** |  **1.00** |    **0.01** |   **4,057 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (115(...)935) [160] | (619(...)658) [156] | (115(...)935) [160] | 98.180 ns | 0.7490 ns | 0.6255 ns |  1.75 |    0.02 |   5,124 B |         - |          NA |
|                |                            |                     |                     |                     |           |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(115(...)935) [160]** | **(115(...)935) [160]** | **(619(...)658) [156]** | **55.214 ns** | **0.1613 ns** | **0.1347 ns** |  **1.00** |    **0.00** |   **4,057 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (115(...)935) [160] | (115(...)935) [160] | (619(...)658) [156] | 98.969 ns | 0.7010 ns | 0.6214 ns |  1.79 |    0.01 |   5,124 B |         - |          NA |
|                |                            |                     |                     |                     |           |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(115(...)935) [160]** | **(115(...)935) [160]** | **(115(...)935) [160]** | **55.759 ns** | **0.2273 ns** | **0.1775 ns** |  **1.00** |    **0.00** |   **4,057 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (115(...)935) [160] | (115(...)935) [160] | (115(...)935) [160] | 98.028 ns | 0.7539 ns | 0.7052 ns |  1.76 |    0.01 |   5,124 B |         - |          NA |


#### after


```
| Method         | EnvironmentVariables       | C                   | A                   | B                   | Mean       | Error     | StdDev    | Ratio | RatioSD | Code Size | Allocated | Alloc Ratio |
|--------------- |--------------------------- |-------------------- |-------------------- |-------------------- |-----------:|----------:|----------:|------:|--------:|----------:|----------:|------------:|
| **AddMod_UInt256** | **Empty**                      | **(619(...)658) [156]** | **(619(...)658) [156]** | **(619(...)658) [156]** |  **45.197 ns** | **0.5057 ns** | **0.4731 ns** |  **1.00** |    **0.01** |   **4,430 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (619(...)658) [156] | (619(...)658) [156] | (619(...)658) [156] |  81.147 ns | 0.6087 ns | 0.5694 ns |  1.80 |    0.02 |   6,259 B |         - |          NA |
|                |                            |                     |                     |                     |            |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(619(...)658) [156]** | **(619(...)658) [156]** | **(115(...)935) [160]** |  **55.656 ns** | **0.1960 ns** | **0.1637 ns** |  **1.00** |    **0.00** |   **4,004 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (619(...)658) [156] | (619(...)658) [156] | (115(...)935) [160] |  98.319 ns | 0.8007 ns | 0.7490 ns |  1.77 |    0.01 |   5,103 B |         - |          NA |
|                |                            |                     |                     |                     |            |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(619(...)658) [156]** | **(115(...)935) [160]** | **(619(...)658) [156]** |  **55.658 ns** | **0.3238 ns** | **0.2704 ns** |  **1.00** |    **0.01** |   **4,004 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (619(...)658) [156] | (115(...)935) [160] | (619(...)658) [156] |  97.076 ns | 0.3054 ns | 0.2707 ns |  1.74 |    0.01 |   5,103 B |         - |          NA |
|                |                            |                     |                     |                     |            |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(619(...)658) [156]** | **(115(...)935) [160]** | **(115(...)935) [160]** |  **56.254 ns** | **0.3116 ns** | **0.2914 ns** |  **1.00** |    **0.01** |   **4,004 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (619(...)658) [156] | (115(...)935) [160] | (115(...)935) [160] |  97.067 ns | 0.3199 ns | 0.2836 ns |  1.73 |    0.01 |   5,103 B |         - |          NA |
|                |                            |                     |                     |                     |            |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(115(...)935) [160]** | **(619(...)658) [156]** | **(619(...)658) [156]** |   **5.869 ns** | **0.0581 ns** | **0.0515 ns** |  **1.00** |    **0.01** |     **986 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (115(...)935) [160] | (619(...)658) [156] | (619(...)658) [156] |  19.572 ns | 0.1608 ns | 0.1426 ns |  3.34 |    0.04 |   2,280 B |         - |          NA |
|                |                            |                     |                     |                     |            |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(115(...)935) [160]** | **(619(...)658) [156]** | **(115(...)935) [160]** |  **55.467 ns** | **0.4505 ns** | **0.3993 ns** |  **1.00** |    **0.01** |   **4,004 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (115(...)935) [160] | (619(...)658) [156] | (115(...)935) [160] | 100.209 ns | 0.6543 ns | 0.5801 ns |  1.81 |    0.02 |   5,103 B |         - |          NA |
|                |                            |                     |                     |                     |            |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(115(...)935) [160]** | **(115(...)935) [160]** | **(619(...)658) [156]** |  **55.399 ns** | **0.3073 ns** | **0.2875 ns** |  **1.00** |    **0.01** |   **4,004 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (115(...)935) [160] | (115(...)935) [160] | (619(...)658) [156] |  98.620 ns | 0.6510 ns | 0.6090 ns |  1.78 |    0.01 |   5,103 B |         - |          NA |
|                |                            |                     |                     |                     |            |           |           |       |         |           |           |             |
| **AddMod_UInt256** | **Empty**                      | **(115(...)935) [160]** | **(115(...)935) [160]** | **(115(...)935) [160]** |  **55.067 ns** | **0.2233 ns** | **0.1864 ns** |  **1.00** |    **0.00** |   **4,004 B** |         **-** |          **NA** |
| AddMod_UInt256 | DOTNET_EnableHWIntrinsic=0 | (115(...)935) [160] | (115(...)935) [160] | (115(...)935) [160] |  97.706 ns | 0.7141 ns | 0.6680 ns |  1.77 |    0.01 |   5,103 B |         - |          NA |

</details>