### PR TITLE
ADD: scalar carry propagation, remove SIMD add paths

### DIFF
--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using FluentAssertions;
@@ -646,6 +647,42 @@ public abstract class UInt256TestsTemplate<T> where T : IInteger<T>
 public class UInt256Tests : UInt256TestsTemplate<UInt256>
 {
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
+
+    // AddOverflow is now scalar-only (the AVX2/Vector256 carry-cascade paths were removed).
+    // These cases pin the carry propagation across every limb boundary and the cascade case
+    // (all-ones lower limbs) that the removed SIMD path handled via the broadcast lookup table.
+    public static IEnumerable<(BigInteger a, BigInteger b, bool overflow)> AddCarryCases()
+    {
+        BigInteger two64 = BigInteger.One << 64;
+        BigInteger two128 = BigInteger.One << 128;
+        BigInteger two192 = BigInteger.One << 192;
+        BigInteger max = TestNumbers.UInt256Max;
+        yield return (BigInteger.Zero, BigInteger.Zero, false);
+        yield return (two64 - 1, BigInteger.One, false);                 // carry u0 -> u1
+        yield return (two128 - 1, BigInteger.One, false);                // carry u0->u1->u2 cascade
+        yield return (two192 - 1, BigInteger.One, false);                // carry through u0,u1,u2 -> u3
+        yield return (max, BigInteger.One, true);                        // full cascade, overflow out of u3
+        yield return (max, max, true);                                   // max + max
+        yield return (two64 - 1, two64 - 1, false);                      // no cross-limb carry past u1
+        yield return (max - 1, BigInteger.One, false);                   // lands exactly on max, no overflow
+    }
+
+    [TestCaseSource(nameof(AddCarryCases))]
+    public void AddOverflow_ScalarCarryPropagation((BigInteger a, BigInteger b, bool overflow) test)
+    {
+        UInt256 a = (UInt256)test.a;
+        UInt256 b = (UInt256)test.b;
+
+        bool overflow = UInt256.AddOverflow(a, b, out UInt256 res);
+        res.Convert(out BigInteger actual);
+
+        actual.Should().Be((test.a + test.b) % (BigInteger.One << 256));
+        overflow.Should().Be(test.overflow);
+
+        // Add (wrapping) must match the low 256 bits regardless of overflow.
+        UInt256.Add(a, b, out UInt256 wrapped);
+        wrapped.Should().Be(res);
+    }
 
     [Test]
     public virtual void Zero_is_min_value()

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -136,16 +136,13 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool AddOverflow(in UInt256 a, in UInt256 b, out UInt256 res)
     {
-        if (!Avx2.IsSupported && !Vector256.IsHardwareAccelerated)
-        {
-            return AddScalar(in a, in b, out res);
-        }
-
-        return Avx2.IsSupported ?
-            AddAvx2(in a, in b, out res) :
-            AddVector256(in a, in b, out res);
+        // Scalar carry propagation. Benchmarking showed the 4-limb scalar add (with the
+        // small-operand fast path below) beats the Vector256/AVX2 carry-cascade approach in the
+        // real production call shape, so the SIMD paths were removed. See PR description.
+        return AddScalar(in a, in b, out res);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool AddScalar(in UInt256 a, in UInt256 b, out UInt256 res)
     {
         ulong a0 = a.u0;
@@ -172,92 +169,6 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
         AddWithCarry(a.u3, b.u3, ref c, out ulong r3);
         res = new UInt256(r0, r1, r2, r3);
         return c != 0;
-    }
-
-    private static bool AddAvx2(in UInt256 a, in UInt256 b, out UInt256 res)
-    {
-        Vector256<ulong> av = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in a));
-        Vector256<ulong> bv = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in b));
-
-        Vector256<ulong> result = Avx2.Add(av, bv);
-        Vector256<ulong> vCarry;
-        if (Avx512F.VL.IsSupported)
-        {
-            vCarry = Avx512F.VL.CompareLessThan(result, av);
-        }
-        else
-        {
-            // Work around for missing Vector256.CompareLessThan
-            Vector256<ulong> carryFromBothHighBits = Avx2.And(av, bv);
-            Vector256<ulong> eitherHighBit = Avx2.Or(av, bv);
-            Vector256<ulong> highBitNotInResult = Avx2.AndNot(result, eitherHighBit);
-
-            // Set high bits where carry occurs
-            vCarry = Avx2.Or(carryFromBothHighBits, highBitNotInResult);
-        }
-        // Move carry from Vector space to uint
-        uint carry = (uint)(Avx512DQ.IsSupported ?
-            Avx512DQ.MoveMask(vCarry) :
-            Avx.MoveMask(vCarry.AsDouble()));
-
-        // All bits set will cascade another carry when carry is added to it
-        Vector256<ulong> vCascade = Avx2.CompareEqual(result, Vector256<ulong>.AllBitsSet);
-        // Move cascade from Vector space to uint
-        uint cascade = (uint)(Avx512DQ.IsSupported ?
-            Avx512DQ.MoveMask(vCascade) :
-            Avx.MoveMask(Unsafe.As<Vector256<ulong>, Vector256<double>>(ref vCascade)));
-
-        // Use ints to work out the Vector cross lane cascades
-        // Move carry to next bit and add cascade
-        carry = cascade + 2 * carry; // lea
-        // Remove cascades not affected by carry
-        cascade ^= carry;
-        // Choice of 16 vectors
-        cascade &= 0x0f;
-
-        // Lookup the carries to broadcast to the Vectors
-        Vector256<ulong> cascadedCarries = Unsafe.Add(ref Unsafe.As<byte, Vector256<ulong>>(ref MemoryMarshal.GetReference(BroadcastLookup)), cascade);
-
-        // Mark res as initialized so we can use it as left side of ref assignment
-        Unsafe.SkipInit(out res);
-        // Add the cascadedCarries to the result
-        Unsafe.As<UInt256, Vector256<ulong>>(ref res) = Avx2.Add(result, cascadedCarries);
-
-        return (carry & 0b1_0000) != 0;
-    }
-
-    private static bool AddVector256(in UInt256 a, in UInt256 b, out UInt256 res)
-    {
-        Vector256<ulong> av = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in a));
-        Vector256<ulong> bv = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in b));
-
-        Vector256<ulong> result = Vector256.Add(av, bv);
-        Vector256<ulong> vCarry = Vector256.LessThan(result, av);
-
-        uint carry = Vector256.ExtractMostSignificantBits(vCarry);
-
-        // All bits set will cascade another carry when carry is added to it
-        Vector256<ulong> vCascade = Vector256.Equals(result, Vector256<ulong>.AllBitsSet);
-        // Move cascade from Vector space to uint
-        uint cascade = Vector256.ExtractMostSignificantBits(vCascade);
-
-        // Use ints to work out the Vector cross lane cascades
-        // Move carry to next bit and add cascade
-        carry = cascade + 2 * carry; // lea
-        // Remove cascades not affected by carry
-        cascade ^= carry;
-        // Choice of 16 vectors
-        cascade &= 0x0f;
-
-        // Lookup the carries to broadcast to the Vectors
-        Vector256<ulong> cascadedCarries = Unsafe.Add(ref Unsafe.As<byte, Vector256<ulong>>(ref MemoryMarshal.GetReference(BroadcastLookup)), cascade);
-
-        // Mark res as initialized so we can use it as left side of ref assignment
-        Unsafe.SkipInit(out res);
-        // Add the cascadedCarries to the result
-        Unsafe.As<UInt256, Vector256<ulong>>(ref res) = Vector256.Add(result, cascadedCarries);
-
-        return (carry & 0b1_0000) != 0;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Routes `UInt256.AddOverflow` through the scalar 4-limb carry chain (`AddScalar`) unconditionally, and removes the now-unreachable `AddAvx2` / `AddVector256` vector paths. `AddScalar` keeps its existing small-operand fast path and gains `AggressiveInlining`.

## Rationale

Microbenchmarking (Codex's screen on the maintainer's machine) showed the scalar add beating the `Vector256`/AVX2 carry-cascade approach in the real production call shape — the SIMD path's cross-lane carry-cascade + broadcast-table lookup has enough fixed overhead that a tight 4-limb `adc`-style scalar chain wins for the 256-bit case.

The carry-cascade `BroadcastLookup` table is **retained** — `Subtract` still uses it on `main` (it's only fully orphaned if the sibling SUB change also lands).

## Tests

- Existing `Add` / `AddOverflow` template suites (BinaryOps) all pass — 127,676 Add-filtered tests, 0 failures.
- Added `AddOverflow_ScalarCarryPropagation` pinning carry across every limb boundary (u0→u1, the u0→u1→u2 cascade, carry into u3) and the full-cascade overflow-out-of-u3 case the removed SIMD path handled via the broadcast lookup.
- Library builds with 0 warnings (confirms no dead code left behind).

## ⚠️ Open question for reviewers — perf justification not yet independently reproduced

This removes a deliberately-built SIMD path, so it deserves scrutiny before merge:

1. **The committed benchmark does not reproduce the win.** The speedup figure came from a separate pre-patch screen; the benchmark in this repo measures scalar-vs-scalar, not scalar-vs-SIMD. A reviewer can't verify the claim from what's committed here.
2. **Not measured across hardware.** The scalar-vs-SIMD comparison needs to be re-run on **AVX2** and **AVX-512** hardware (and the no-intrinsics job), in the real production call shape, before concluding scalar is the right default. The win may not hold on AVX-512 parts.
3. **EVM-level context.** A prior int256-focused gas benchmark (against the Nethermind client) showed **no ADD/SUB/LT bottleneck** at the EVM layer — the only beyond-noise signal was MULMOD. So even if scalar wins microbenchmarks, the block-level payoff of this specific change is likely negligible.

**Recommendation:** treat this as a proposal pending an apples-to-apples AVX2/AVX-512 measurement. Correctness is solid; the perf case is not yet proven in-repo.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
