### PR TITLE
LT/GT: scalar limb compare, remove SIMD LessThan paths

### DIFF
--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using FluentAssertions;
@@ -646,6 +647,44 @@ public abstract class UInt256TestsTemplate<T> where T : IInteger<T>
 public class UInt256Tests : UInt256TestsTemplate<UInt256>
 {
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
+
+    // operator< / LessThan are now scalar high-to-low limb compares (the AVX2/Vector256 mask
+    // paths were removed). These cases pin the decision at each limb position (the difference
+    // must be resolved by the most-significant differing limb), equality, and the derived
+    // operators (>, <=, >=) which are defined in terms of <.
+    public static IEnumerable<(BigInteger a, BigInteger b)> ComparePairs()
+    {
+        BigInteger two64 = BigInteger.One << 64;
+        BigInteger two128 = BigInteger.One << 128;
+        BigInteger two192 = BigInteger.One << 192;
+        BigInteger max = TestNumbers.UInt256Max;
+        yield return (BigInteger.Zero, BigInteger.Zero);                 // equal
+        yield return (max, max);                                        // equal at all-ones
+        yield return (BigInteger.Zero, BigInteger.One);                 // differ in u0
+        yield return (two64, two64 + 1);                                // differ in u0, equal u1
+        yield return (two64 - 1, two64);                                // u0 high vs u1 set: u1 decides
+        yield return (two128, two128 + (two64 - 1));                    // differ in u1, equal u2/u3
+        yield return (two128 - 1, two128);                              // u2 differs, lower limbs misleading
+        yield return (two192, two192 + (two128 - 1));                   // differ in u2, equal u3
+        yield return (two192 - 1, two192);                              // u3 differs, lower limbs all-ones
+        yield return (max - 1, max);                                    // differ only in u0 at the top
+    }
+
+    [TestCaseSource(nameof(ComparePairs))]
+    public void Comparison_ScalarLimbCompare_MatchesBigInteger((BigInteger a, BigInteger b) test)
+    {
+        UInt256 a = (UInt256)test.a;
+        UInt256 b = (UInt256)test.b;
+
+        (a < b).Should().Be(test.a < test.b);
+        (b < a).Should().Be(test.b < test.a);
+        (a > b).Should().Be(test.a > test.b);
+        (a <= b).Should().Be(test.a <= test.b);
+        (a >= b).Should().Be(test.a >= test.b);
+        // Reflexivity / antisymmetry sanity
+        (a < a).Should().BeFalse();
+        (a <= a).Should().BeTrue();
+    }
 
     [Test]
     public virtual void Zero_is_min_value()

--- a/src/Nethermind.Int256/UInt256.Operators.cs
+++ b/src/Nethermind.Int256/UInt256.Operators.cs
@@ -183,7 +183,18 @@ public readonly partial struct UInt256
         return c;
     }
 
-    public static bool operator <(in UInt256 a, in UInt256 b) => LessThan(in a, in b);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <(in UInt256 a, in UInt256 b)
+    {
+        // Direct scalar high-to-low limb compare (the SIMD LessThan path was removed).
+        if (a.u3 != b.u3)
+            return a.u3 < b.u3;
+        if (a.u2 != b.u2)
+            return a.u2 < b.u2;
+        if (a.u1 != b.u1)
+            return a.u1 < b.u1;
+        return a.u0 < b.u0;
+    }
     public static bool operator <(in UInt256 a, int b) => LessThan(in a, b);
     public static bool operator <(int a, in UInt256 b) => LessThan(a, in b);
     public static bool operator <(in UInt256 a, uint b) => LessThan(in a, b);
@@ -192,7 +203,8 @@ public readonly partial struct UInt256
     public static bool operator <(long a, in UInt256 b) => LessThan(a, in b);
     public static bool operator <(in UInt256 a, ulong b) => LessThan(in a, b);
     public static bool operator <(ulong a, in UInt256 b) => LessThan(a, in b);
-    public static bool operator <=(in UInt256 a, in UInt256 b) => !LessThan(in b, in a);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <=(in UInt256 a, in UInt256 b) => !(b < a);
     public static bool operator <=(in UInt256 a, int b) => !LessThan(b, in a);
     public static bool operator <=(int a, in UInt256 b) => !LessThan(in b, a);
     public static bool operator <=(in UInt256 a, uint b) => !LessThan(b, in a);
@@ -201,7 +213,8 @@ public readonly partial struct UInt256
     public static bool operator <=(long a, in UInt256 b) => !LessThan(in b, a);
     public static bool operator <=(in UInt256 a, ulong b) => !LessThan(b, in a);
     public static bool operator <=(ulong a, UInt256 b) => !LessThan(in b, a);
-    public static bool operator >(in UInt256 a, in UInt256 b) => LessThan(in b, in a);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >(in UInt256 a, in UInt256 b) => b < a;
     public static bool operator >(in UInt256 a, int b) => LessThan(b, in a);
     public static bool operator >(int a, in UInt256 b) => LessThan(in b, a);
     public static bool operator >(in UInt256 a, uint b) => LessThan(b, in a);
@@ -210,7 +223,8 @@ public readonly partial struct UInt256
     public static bool operator >(long a, in UInt256 b) => LessThan(in b, a);
     public static bool operator >(in UInt256 a, ulong b) => LessThan(b, in a);
     public static bool operator >(ulong a, in UInt256 b) => LessThan(in b, a);
-    public static bool operator >=(in UInt256 a, in UInt256 b) => !LessThan(in a, in b);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >=(in UInt256 a, in UInt256 b) => !(a < b);
     public static bool operator >=(in UInt256 a, int b) => !LessThan(in a, b);
     public static bool operator >=(int a, in UInt256 b) => !LessThan(a, in b);
     public static bool operator >=(in UInt256 a, uint b) => !LessThan(in a, b);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1127,14 +1127,10 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool LessThan(in UInt256 a, in UInt256 b)
     {
-        if (!Avx2.IsSupported && !Vector256.IsHardwareAccelerated)
-        {
-            return LessThanScalar(in a, in b);
-        }
-
-        return Avx2.IsSupported ?
-            LessThanAvx2(in a, in b) :
-            LessThanVector256(in a, in b);
+        // Scalar high-to-low limb compare. Benchmarking showed it beats the AVX2/Vector256
+        // mask-based compare in the real production call shape, so the SIMD paths were removed.
+        // See PR description. LessThanScalar is retained because LessThanBoth still uses it.
+        return LessThanScalar(in a, in b);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1147,61 +1143,6 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
         if (a.u1 != b.u1)
             return a.u1 < b.u1;
         return a.u0 < b.u0;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool LessThanAvx2(in UInt256 a, in UInt256 b)
-    {
-        // Load the four 64-bit words into a 256-bit register.
-        Vector256<ulong> vecL = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in a));
-        Vector256<ulong> vecR = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in b));
-
-        uint eqMask;
-        uint ltMask;
-        if (Avx512F.VL.IsSupported && Avx512DQ.IsSupported)
-        {
-            // Best case: AVX-512 compare produces k-mask; MoveMask uses KMOVB.
-            // Avx512DQ.MoveMask is documented as KMOVB r32,k1.
-            eqMask = (uint)Avx512DQ.MoveMask(Avx512F.VL.CompareEqual(vecL, vecR));     // VPCMPUQ + KMOVB
-            ltMask = (uint)Avx512DQ.MoveMask(Avx512F.VL.CompareLessThan(vecL, vecR));  // VPCMPUQ + KMOVB
-        }
-        else
-        {
-            // Equality mask - AVX2 compare -> movmskpd
-            eqMask = (uint)Avx.MoveMask(Avx2.CompareEqual(vecL, vecR).AsDouble());
-            // AVX2 unsigned-compare trick (flip sign bit, signed compare)
-            var signFlip = Vector256.Create(0x8000_0000_0000_0000UL);
-            Vector256<long> sL = Avx2.Xor(vecL, signFlip).AsInt64();
-            Vector256<long> sR = Avx2.Xor(vecR, signFlip).AsInt64();
-            ltMask = (uint)Avx.MoveMask(Avx2.CompareGreaterThan(sR, sL).AsDouble());
-        }
-
-        uint diff = eqMask ^ 0xFu;
-        if (diff == 0) return false;
-
-        // Slightly nicer than BitOperations.Log2 here:
-        // diff != 0 and diff <= 0xF => LZCNT in [28..31] => (31 - lzcnt) == (31 ^ lzcnt)
-        int idx = BitOperations.LeadingZeroCount(diff) ^ 31;
-        return ((ltMask >> idx) & 1u) != 0;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool LessThanVector256(in UInt256 a, in UInt256 b)
-    {
-        // Load the four 64-bit words into a 256-bit register.
-        Vector256<ulong> vecL = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in a));
-        Vector256<ulong> vecR = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in b));
-
-        uint eqMask = Vector256.ExtractMostSignificantBits(Vector256.Equals(vecL, vecR));
-        uint ltMask = Vector256.ExtractMostSignificantBits(Vector256.LessThan(vecL, vecR));
-
-        uint diff = eqMask ^ 0xFu;
-        if (diff == 0) return false;
-
-        // Slightly nicer than BitOperations.Log2 here:
-        // diff != 0 and diff <= 0xF => LZCNT in [28..31] => (31 - lzcnt) == (31 ^ lzcnt)
-        int idx = BitOperations.LeadingZeroCount(diff) ^ 31;
-        return ((ltMask >> idx) & 1u) != 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary

Makes the `UInt256`-vs-`UInt256` `LessThan` a scalar high-to-low limb compare unconditionally, inlines the same compare into `operator <` (with `AggressiveInlining`), and defines `operator >` / `<=` / `>=` in terms of it. Removes the now-unreachable `LessThanAvx2` / `LessThanVector256` vector paths.

`LessThanScalar` is **retained** — `LessThanBoth` (used by `AddMod`/`MulMod`) still calls it, and the `LessThanBoth*` SIMD variants are unaffected by this PR.

## Rationale

Microbenchmarking (Codex's screen on the maintainer's machine) showed the scalar limb compare beating the AVX2/Vector256 mask-based compare in the real production call shape — for a single comparison the SIMD path's vector load + compare + movemask + lzcnt has more fixed overhead than a short branchy high-to-low limb compare that usually resolves on the top limb.

## Tests

- Existing `ComparisonOperators` / `LessThan` template suites pass — 2,314 comparison-filtered tests, 0 failures.
- Added `Comparison_ScalarLimbCompare_MatchesBigInteger` pinning the compare decision at **each** limb position (the result must be resolved by the most-significant differing limb, with lower limbs deliberately misleading), equality, and the derived `>` / `<=` / `>=` operators — all cross-checked against `BigInteger`.
- Library builds with 0 warnings (confirms no dead code left behind).

## ⚠️ Open question for reviewers — perf justification not yet independently reproduced

This removes a deliberately-built SIMD path, so it deserves scrutiny before merge:

1. **The committed benchmark does not reproduce the win.** The speedup figure came from a separate pre-patch screen; the benchmark in this repo measures scalar-vs-scalar, not scalar-vs-SIMD. A reviewer can't verify the claim from what's committed here.
2. **Not measured across hardware.** The scalar-vs-SIMD comparison needs to be re-run on **AVX2** and **AVX-512** hardware (and the no-intrinsics job), in the real production call shape, before concluding scalar is the right default.
3. **EVM-level context.** A prior int256-focused gas benchmark (against the Nethermind client) showed **no ADD/SUB/LT bottleneck** at the EVM layer — the only beyond-noise signal was MULMOD. So even if scalar wins microbenchmarks, the block-level payoff of this specific change is likely negligible.

**Recommendation:** treat this as a proposal pending an apples-to-apples AVX2/AVX-512 measurement. Correctness is solid; the perf case is not yet proven in-repo. (Sibling PRs: ADD #87, SUB #88.)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
