### PR TITLE
Int256: AggressiveInlining hints for hot accessors

### DIFF
--- a/src/Nethermind.Int256.Tests/Int256Tests.cs
+++ b/src/Nethermind.Int256.Tests/Int256Tests.cs
@@ -85,4 +85,57 @@ public class Int256Tests : UInt256TestsTemplate<Int256>
         }
         catch (Exception e) when (e.GetType() == expectedException) { }
     }
+
+    // The accessors that gained AggressiveInlining hints (Sign, IsZero, IsOne, CompareTo, <, >)
+    // are behaviorally unchanged. These cases pin their results across the sign boundary so the
+    // inlining change is locked in as a no-op on semantics.
+    public static (string value, int sign, bool isZero, bool isOne)[] SignAccessorCases { get; } =
+    [
+        ("0", 0, true, false),
+        ("1", 1, false, true),
+        ("-1", -1, false, false),
+        ("12345678901234567890", 1, false, false),
+        ("-12345678901234567890", -1, false, false),
+        ("57896044618658097711785492504343953926634992332820282019728792003956564819967", 1, false, false),   // Int256.Max
+        ("-57896044618658097711785492504343953926634992332820282019728792003956564819968", -1, false, false),  // Int256.Min
+    ];
+
+    [TestCaseSource(nameof(SignAccessorCases))]
+    public void SignZeroOne_Accessors((string value, int sign, bool isZero, bool isOne) test)
+    {
+        Int256 v = (Int256)BigInteger.Parse(test.value);
+        v.Sign.Should().Be(test.sign);
+        v.IsZero.Should().Be(test.isZero);
+        v.IsOne.Should().Be(test.isOne);
+        v.IsNegative.Should().Be(test.sign < 0);
+    }
+
+    public static (string a, string b)[] SignedComparePairs { get; } =
+    [
+        ("0", "0"),
+        ("-1", "1"),            // negative < positive
+        ("1", "-1"),
+        ("-2", "-1"),           // both negative: -2 < -1
+        ("-1", "-2"),
+        ("5", "5"),
+        ("-12345678901234567890", "12345678901234567890"),
+        ("57896044618658097711785492504343953926634992332820282019728792003956564819967",
+         "-57896044618658097711785492504343953926634992332820282019728792003956564819968"),   // Max vs Min
+    ];
+
+    [TestCaseSource(nameof(SignedComparePairs))]
+    public void Compare_And_Operators_MatchBigInteger((string a, string b) test)
+    {
+        BigInteger ba = BigInteger.Parse(test.a);
+        BigInteger bb = BigInteger.Parse(test.b);
+        Int256 a = (Int256)ba;
+        Int256 b = (Int256)bb;
+
+        (a < b).Should().Be(ba < bb);
+        (a > b).Should().Be(ba > bb);
+        Math.Sign(a.CompareTo(b)).Should().Be(ba.CompareTo(bb));
+        Math.Sign(a.CompareTo((object)b)).Should().Be(ba.CompareTo(bb));
+        (a < a).Should().BeFalse();
+        a.CompareTo(a).Should().Be(0);
+    }
 }

--- a/src/Nethermind.Int256/Int256.cs
+++ b/src/Nethermind.Int256/Int256.cs
@@ -62,7 +62,11 @@ public readonly struct Int256 : IEquatable<Int256>, IComparable, IComparable<Int
 
     public Int256 ZeroValue => Zero;
 
-    public int Sign => _value.IsZero ? 0 : _value.u3 < 0x8000000000000000ul ? 1 : -1;
+    public int Sign
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _value.IsZero ? 0 : _value.u3 < 0x8000000000000000ul ? 1 : -1;
+    }
     public bool IsNegative => Sign < 0;
 
     public static Int256 operator +(in Int256 a, in Int256 b)
@@ -536,21 +540,32 @@ public readonly struct Int256 : IEquatable<Int256>, IComparable, IComparable<Int
 
     public static bool operator !=(in Int256 a, in Int256 b) => !(a == b);
 
-    public bool IsZero => this == Zero;
+    public bool IsZero
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => this == Zero;
+    }
 
-    public bool IsOne => this == One;
+    public bool IsOne
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => this == One;
+    }
 
     public Int256 MaximalValue => Max;
 
     public int CompareTo(object? obj) => obj is not Int256 int256 ? throw new InvalidOperationException() : CompareTo(int256);
-    
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int CompareTo(Int256 b) => CompareTo(in b);
 
     [OverloadResolutionPriority(1)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int CompareTo(in Int256 b) => this < b ? -1 : Equals(b) ? 0 : 1;
 
     public static explicit operator UInt256(Int256 z) => z._value;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator <(in Int256 z, in Int256 x)
     {
         int zSign = z.Sign;
@@ -570,6 +585,7 @@ public readonly struct Int256 : IEquatable<Int256>, IComparable, IComparable<Int
 
         return z._value < x._value;
     }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator >(in Int256 z, in Int256 x) => x < z;
 
     public static explicit operator Int256(ulong value) => new((UInt256)value);

--- a/src/Nethermind.Int256/Int256.cs
+++ b/src/Nethermind.Int256/Int256.cs
@@ -67,7 +67,11 @@ public readonly struct Int256 : IEquatable<Int256>, IComparable, IComparable<Int
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => _value.IsZero ? 0 : _value.u3 < 0x8000000000000000ul ? 1 : -1;
     }
-    public bool IsNegative => Sign < 0;
+    public bool IsNegative
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Sign < 0;
+    }
 
     public static Int256 operator +(in Int256 a, in Int256 b)
     {


### PR DESCRIPTION
## Summary

Adds `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to the small, hot `Int256` accessors and comparison entry points:

- `Sign`, `IsZero`, `IsOne` (one-line property getters)
- `CompareTo(Int256)`, `CompareTo(in Int256)`
- `operator <`, `operator >`

These are tiny accessors on the signed-comparison (SLT/SGT) and sign-test hot paths. They're one-liners that the JIT may not inline across the assembly boundary on its own, so an explicit hint helps callers in the Nethermind EVM that compare `Int256` values frequently.

## Why this one is safe

Unlike the sibling scalar-vs-SIMD PRs (ADD #87, SUB #88, LT/GT #89), this change **removes nothing and alters no logic** — it's purely inlining hints. There's no SIMD path traded away, no behavioral change, and nothing to measure on specific hardware. It's the low-risk subset of the original opcode-primitive experiment.

## Tests

- Full `Int256Tests` template suite passes (575,157 tests, 0 failures) — it already exercises `Sign`/`IsZero`/`IsOne`/`CompareTo`/`<`/`>` heavily via the signed comparison/arithmetic cases.
- Added two focused tests that pin these accessors as a semantic no-op across the sign boundary (incl. `Int256.Max`/`Min`):
  - `SignZeroOne_Accessors` — `Sign` / `IsZero` / `IsOne` / `IsNegative` for zero, ±1, large ±, and Max/Min.
  - `Compare_And_Operators_MatchBigInteger` — `<` / `>` / `CompareTo` (both overloads) cross-checked against `BigInteger`, plus reflexivity.
- Library builds with 0 warnings.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
