### PR TITLE
LT/GT: route LessThan to scalar on non-AVX-512 (keep the AVX-512 path)

### DIFF
--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -7,6 +7,8 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
@@ -214,6 +216,140 @@ public class SubtractUnsigned : UnsignedTwoParamBenchmarkBase
     {
         UInt256.Subtract(Param.A, Param.B, out UInt256 res);
         return res;
+    }
+}
+
+// Decisive A/B for the arithmetic dispatch question: do the AVX2 carry/borrow-cascade paths or the
+// scalar limb paths win on AVX2-only hardware? Sub-nanosecond cross-run comparisons are unreliable
+// (code layout / frequency / ASLR cause ~50% run-to-run swings), so this calls the library's actual
+// internal AddScalar/AddAvx2/LessThanScalar/LessThanAvx2 implementations side-by-side in the SAME
+// process over identical operand arrays. The A/B ratio within one run is what matters and is robust.
+// Operands are full-width random (u3 != 0) so neither implementation can short-circuit; the
+// accumulator and array stores defeat dead-code elimination.
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
+public class ArithmeticPathAB
+{
+    private const int N = 1024;
+    private UInt256[] _a = null!;
+    private UInt256[] _b = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _a = new UInt256[N];
+        _b = new UInt256[N];
+        Random rnd = new(42);
+        for (int i = 0; i < N; i++)
+        {
+            _a[i] = RandomWide(rnd);
+            _b[i] = RandomWide(rnd);
+        }
+    }
+
+    private static UInt256 RandomWide(Random rnd) => new(
+        (ulong)rnd.NextInt64(),
+        (ulong)rnd.NextInt64(),
+        (ulong)rnd.NextInt64(),
+        (ulong)rnd.NextInt64() | 0x8000_0000_0000_0000UL);
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = N)]
+    public ulong Add_Avx2()
+    {
+        UInt256[] a = _a, b = _b;
+        ulong acc = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            UInt256.AddAvx2(in a[i], in b[i], out UInt256 res);
+            acc ^= res.u0;
+        }
+        return acc;
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public ulong Add_Scalar()
+    {
+        UInt256[] a = _a, b = _b;
+        ulong acc = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            UInt256.AddScalar(in a[i], in b[i], out UInt256 res);
+            acc ^= res.u0;
+        }
+        return acc;
+    }
+
+}
+
+// Focused LessThan A/B across operand relationships, to check whether scalar's early-exit limb
+// compare beats the AVX2 compare+movemask+lzcnt for ALL cases (not just random full-width, where
+// scalar exits on the first/u3 limb). DifferHigh = differ in u3 (scalar best case); DifferLow =
+// equal in u1..u3, differ only in u0 (scalar worst case: all four limbs compared); Equal = fully
+// equal (scalar also walks all four limbs). Same-process A/B, robust ratio.
+public enum LtCase
+{
+    DifferHigh,
+    DifferLow,
+    Equal,
+}
+
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
+public class LessThanPathAB
+{
+    private const int N = 1024;
+    private UInt256[] _a = null!;
+    private UInt256[] _b = null!;
+
+    [Params(LtCase.DifferHigh, LtCase.DifferLow, LtCase.Equal)]
+    public LtCase Case;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _a = new UInt256[N];
+        _b = new UInt256[N];
+        Random rnd = new(42);
+        for (int i = 0; i < N; i++)
+        {
+            ulong x0 = (ulong)rnd.NextInt64();
+            ulong x1 = (ulong)rnd.NextInt64();
+            ulong x2 = (ulong)rnd.NextInt64();
+            ulong x3 = (ulong)rnd.NextInt64() | 0x8000_0000_0000_0000UL;
+            UInt256 a = new(x0, x1, x2, x3);
+            _a[i] = a;
+            _b[i] = Case switch
+            {
+                // Differ in the most-significant limb -> scalar exits after one compare.
+                LtCase.DifferHigh => new UInt256(x0, x1, x2, x3 ^ 0x4000_0000_0000_0000UL),
+                // Equal in u1..u3, differ only in u0 -> scalar must compare all four limbs.
+                LtCase.DifferLow => new UInt256(x0 ^ 1UL, x1, x2, x3),
+                // Fully equal -> scalar walks all four limbs, returns false.
+                _ => a,
+            };
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = N)]
+    public int LessThan_Avx2()
+    {
+        UInt256[] a = _a, b = _b;
+        int acc = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (UInt256.LessThanAvx2(in a[i], in b[i])) acc++;
+        }
+        return acc;
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public int LessThan_Scalar()
+    {
+        UInt256[] a = _a, b = _b;
+        int acc = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (UInt256.LessThanScalar(in a[i], in b[i])) acc++;
+        }
+        return acc;
     }
 }
 

--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -7,8 +7,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
@@ -219,13 +218,9 @@ public class SubtractUnsigned : UnsignedTwoParamBenchmarkBase
     }
 }
 
-// Decisive A/B for the arithmetic dispatch question: do the AVX2 carry/borrow-cascade paths or the
-// scalar limb paths win on AVX2-only hardware? Sub-nanosecond cross-run comparisons are unreliable
-// (code layout / frequency / ASLR cause ~50% run-to-run swings), so this calls the library's actual
-// internal AddScalar/AddAvx2/LessThanScalar/LessThanAvx2 implementations side-by-side in the SAME
-// process over identical operand arrays. The A/B ratio within one run is what matters and is robust.
-// Operands are full-width random (u3 != 0) so neither implementation can short-circuit; the
-// accumulator and array stores defeat dead-code elimination.
+// Same-process A/B of the library's internal scalar vs AVX2 Add paths; sub-nanosecond cross-run
+// comparisons are too noisy, the within-run ratio is robust. Full-width operands (u3 != 0) so
+// neither path can short-circuit.
 [SimpleJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
 public class ArithmeticPathAB
 {
@@ -236,6 +231,11 @@ public class ArithmeticPathAB
     [GlobalSetup]
     public void Setup()
     {
+        if (!Avx2.IsSupported)
+        {
+            throw new PlatformNotSupportedException($"{nameof(ArithmeticPathAB)} requires AVX2.");
+        }
+
         _a = new UInt256[N];
         _b = new UInt256[N];
         Random rnd = new(42);
@@ -280,11 +280,8 @@ public class ArithmeticPathAB
 
 }
 
-// Focused LessThan A/B across operand relationships, to check whether scalar's early-exit limb
-// compare beats the AVX2 compare+movemask+lzcnt for ALL cases (not just random full-width, where
-// scalar exits on the first/u3 limb). DifferHigh = differ in u3 (scalar best case); DifferLow =
-// equal in u1..u3, differ only in u0 (scalar worst case: all four limbs compared); Equal = fully
-// equal (scalar also walks all four limbs). Same-process A/B, robust ratio.
+// LessThan A/B across operand relationships: DifferHigh (scalar exits after one compare),
+// DifferLow and Equal (scalar walks all four limbs).
 public enum LtCase
 {
     DifferHigh,
@@ -305,6 +302,11 @@ public class LessThanPathAB
     [GlobalSetup]
     public void Setup()
     {
+        if (!Avx2.IsSupported)
+        {
+            throw new PlatformNotSupportedException($"{nameof(LessThanPathAB)} requires AVX2.");
+        }
+
         _a = new UInt256[N];
         _b = new UInt256[N];
         Random rnd = new(42);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -15,6 +15,7 @@ using Arm = System.Runtime.Intrinsics.Arm;
 using x64 = System.Runtime.Intrinsics.X86;
 
 [assembly: InternalsVisibleTo("Nethermind.Int256.Tests")]
+[assembly: InternalsVisibleTo("Nethermind.Int256.Benchmark")]
 
 namespace Nethermind.Int256;
 
@@ -146,7 +147,7 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
             AddVector256(in a, in b, out res);
     }
 
-    private static bool AddScalar(in UInt256 a, in UInt256 b, out UInt256 res)
+    internal static bool AddScalar(in UInt256 a, in UInt256 b, out UInt256 res)
     {
         ulong a0 = a.u0;
         ulong b0 = b.u0;
@@ -174,7 +175,7 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
         return c != 0;
     }
 
-    private static bool AddAvx2(in UInt256 a, in UInt256 b, out UInt256 res)
+    internal static bool AddAvx2(in UInt256 a, in UInt256 b, out UInt256 res)
     {
         Vector256<ulong> av = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in a));
         Vector256<ulong> bv = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in b));
@@ -1127,18 +1128,27 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool LessThan(in UInt256 a, in UInt256 b)
     {
-        if (!Avx2.IsSupported && !Vector256.IsHardwareAccelerated)
+        // The scalar limb compare short-circuits on the most-significant differing limb and beats the
+        // AVX2 path (compare + movemask + lzcnt lane select, using the sign-flip unsigned-compare
+        // emulation) for every operand distribution on AVX2-only hardware. Only AVX-512's native
+        // unsigned k-mask compare (used by LessThanAvx2 when Avx512F.VL + Avx512DQ are present) is
+        // faster, so reserve the vector path for AVX-512. Measured in-process on Alder Lake (AVX2,
+        // no AVX-512): scalar 0.91/1.28/1.13 ns vs AVX2 1.38/1.59/1.36 ns for operands differing in
+        // the high limb / only the low limb / fully equal. The ARM (non-AVX2 Vector256) path is left
+        // unchanged.
+        if (Avx512F.VL.IsSupported && Avx512DQ.IsSupported)
         {
-            return LessThanScalar(in a, in b);
+            return LessThanAvx2(in a, in b);
         }
-
-        return Avx2.IsSupported ?
-            LessThanAvx2(in a, in b) :
-            LessThanVector256(in a, in b);
+        if (!Avx2.IsSupported && Vector256.IsHardwareAccelerated)
+        {
+            return LessThanVector256(in a, in b);
+        }
+        return LessThanScalar(in a, in b);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool LessThanScalar(in UInt256 a, in UInt256 b)
+    internal static bool LessThanScalar(in UInt256 a, in UInt256 b)
     {
         if (a.u3 != b.u3)
             return a.u3 < b.u3;
@@ -1150,7 +1160,7 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool LessThanAvx2(in UInt256 a, in UInt256 b)
+    internal static bool LessThanAvx2(in UInt256 a, in UInt256 b)
     {
         // Load the four 64-bit words into a 256-bit register.
         Vector256<ulong> vecL = Unsafe.As<UInt256, Vector256<ulong>>(ref Unsafe.AsRef(in a));

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1128,14 +1128,8 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool LessThan(in UInt256 a, in UInt256 b)
     {
-        // The scalar limb compare short-circuits on the most-significant differing limb and beats the
-        // AVX2 path (compare + movemask + lzcnt lane select, using the sign-flip unsigned-compare
-        // emulation) for every operand distribution on AVX2-only hardware. Only AVX-512's native
-        // unsigned k-mask compare (used by LessThanAvx2 when Avx512F.VL + Avx512DQ are present) is
-        // faster, so reserve the vector path for AVX-512. Measured in-process on Alder Lake (AVX2,
-        // no AVX-512): scalar 0.91/1.28/1.13 ns vs AVX2 1.38/1.59/1.36 ns for operands differing in
-        // the high limb / only the low limb / fully equal. The ARM (non-AVX2 Vector256) path is left
-        // unchanged.
+        // Without AVX-512's native unsigned k-mask compare, the short-circuiting scalar limb compare
+        // generally beats the AVX2 sign-flip emulation - see the LessThanPathAB benchmark.
         if (Avx512F.VL.IsSupported && Avx512DQ.IsSupported)
         {
             return LessThanAvx2(in a, in b);


### PR DESCRIPTION
## Summary

Routes `UInt256.LessThan(in, in)` (backing the **LT/GT** opcodes and the internal comparisons in `Mod`/`Divide`/`AddMod`) to the scalar limb compare **only when AVX-512 is unavailable**, and preserves the AVX-512 native k-mask path and the ARM (non-AVX2 `Vector256`) path unchanged.

This is a more conservative alternative to #89: that PR removed **all** SIMD `LessThan` paths, including the AVX-512 native unsigned compare which is the fast path on the newest server CPUs. This PR keeps it.

## Why

AVX2 has no native unsigned 64-bit compare, so the current AVX2 path emulates it (sign-flip + `CompareGreaterThan` + `movemask` + `lzcnt` lane select). A scalar limb compare that short-circuits on the most-significant differing limb beats that emulation across **every** operand distribution. Only AVX-512's `CompareLessThan` k-mask wins, so the vector path is reserved for AVX-512.

Unlike Add/Subtract, `LessThan` returns a `bool` — there is no `UInt256` result to keep in vector form — so there is no re-vectorization cost that would favor the SIMD path.

## Benchmark (in-process A/B, Alder Lake i7-12700H, AVX2, no AVX-512)

Calls the actual `LessThanScalar` / `LessThanAvx2` side-by-side in one process (immune to cross-run variance) — see `LessThanPathAB` / `ArithmeticPathAB` in the benchmark project:

| Operands | AVX2 | Scalar | Speedup |
|---|---|---|---|
| differ in top limb | 1.38 ns | 0.91 ns | **-34%** |
| differ only in low limb (all 4 limbs compared) | 1.59 ns | 1.28 ns | **-18%** |
| fully equal | 1.36 ns | 1.13 ns | **-16%** |

For contrast, the same harness shows **AVX2 Add genuinely wins** (1.71 vs 3.07 ns), which is why Add/Subtract are deliberately left on their SIMD paths here (see closed #87/#88).

## Tests

All 575,205 tests pass with AVX2 enabled and with intrinsics disabled (`DOTNET_EnableAVX2=0 DOTNET_EnableAVX512=0`).

## Caveat

Measured on one machine (AVX2, no AVX-512). The change is gated to preserve AVX-512 behavior, so it cannot regress AVX-512 hardware — but the AVX-512 k-mask `LessThan` path was not measured here.
