### PR TITLE
ADDMOD: skip wasted DivRems in the 64-bit-modulus reduction for small sums

### DIFF
--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.Intrinsics.X86;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
@@ -703,6 +704,124 @@ public class ParseDecimalUnsigned : ParseUnsignedBenchmarkBase
         return UInt256.TryParse(Value, out _);
     }
 }
+
+// In-process A/B for the ADDMOD-by-64-bit-modulus reduction (Remainder257By64BitsX86Base). The
+// current code issues four 64-bit hardware DivRems unconditionally (one per limb of the 257-bit
+// sum). x86 DIV is ~20-40 cycles, so when the sum fits in <=128 bits - the common case when ADDMOD's
+// operands are already reduced (x,y < m < 2^64), giving a sum < 2^65 - two or three of those divides
+// are pure waste (dividing zero high limbs). FastPath detects (u2|u3|carry)==0 and reduces the
+// 128-bit (u1:u0) value with one DivRem when u1<d, else two. The Full case (sum > 128 bits) takes the
+// same four-DivRem path in both, so it is a no-regression guard. Operands generated from a fixed seed.
+public enum SumWidth
+{
+    Small,   // x,y < 2^64  => sum < 2^65 (u1 in {0,1}); 1 DivRem on the fast path
+    Mid128,  // sum is a full 128-bit value (u1 large, < d not guaranteed); 2 DivRems on the fast path
+    Full,    // full 257-bit sum; 4 DivRems on both paths (regression guard)
+}
+
+#pragma warning disable SYSLIB5004 // X86Base.X64.DivRem is [Experimental]; the library already uses it
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
+public class AddModReduce64AB
+{
+    private const int N = 1024;
+    private ulong[] _u0 = null!;
+    private ulong[] _u1 = null!;
+    private ulong[] _u2 = null!;
+    private ulong[] _u3 = null!;
+    private ulong[] _a4 = null!;
+    private ulong[] _d = null!;
+
+    [Params(SumWidth.Small, SumWidth.Mid128, SumWidth.Full)]
+    public SumWidth Width;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _u0 = new ulong[N];
+        _u1 = new ulong[N];
+        _u2 = new ulong[N];
+        _u3 = new ulong[N];
+        _a4 = new ulong[N];
+        _d = new ulong[N];
+        Random rnd = new(42);
+        for (int i = 0; i < N; i++)
+        {
+            _d[i] = (ulong)rnd.NextInt64(2, long.MaxValue); // 64-bit modulus, >= 2
+            _u0[i] = (ulong)rnd.NextInt64();
+            switch (Width)
+            {
+                case SumWidth.Small:
+                    _u1[i] = (ulong)(rnd.NextInt64() & 1); // 0 or 1 (carry out of u0)
+                    _u2[i] = 0; _u3[i] = 0; _a4[i] = 0;
+                    break;
+                case SumWidth.Mid128:
+                    _u1[i] = (ulong)rnd.NextInt64() | 0x8000_0000_0000_0000UL; // large high limb
+                    _u2[i] = 0; _u3[i] = 0; _a4[i] = 0;
+                    break;
+                default: // Full
+                    _u1[i] = (ulong)rnd.NextInt64();
+                    _u2[i] = (ulong)rnd.NextInt64();
+                    _u3[i] = (ulong)rnd.NextInt64();
+                    _a4[i] = (ulong)(rnd.NextInt64() & 1);
+                    break;
+            }
+        }
+    }
+
+    // Current: four hardware DivRems, one per limb (matches Remainder257By64BitsX86Base).
+    [Benchmark(Baseline = true, OperationsPerInvoke = N)]
+    public ulong Current()
+    {
+        ulong[] u0 = _u0, u1 = _u1, u2 = _u2, u3 = _u3, a4 = _a4, d = _d;
+        ulong acc = 0;
+        for (int i = 0; i < u0.Length; i++)
+        {
+            ulong dd = d[i];
+            ulong r = X86Base.X64.DivRem(u3[i], a4[i], dd).Remainder;
+            r = X86Base.X64.DivRem(u2[i], r, dd).Remainder;
+            r = X86Base.X64.DivRem(u1[i], r, dd).Remainder;
+            r = X86Base.X64.DivRem(u0[i], r, dd).Remainder;
+            acc ^= r;
+        }
+        return acc;
+    }
+
+    // Fast path: skip the wasted divides when the sum fits in <=128 bits.
+    [Benchmark(OperationsPerInvoke = N)]
+    public ulong FastPath()
+    {
+        ulong[] u0 = _u0, u1 = _u1, u2 = _u2, u3 = _u3, a4 = _a4, d = _d;
+        ulong acc = 0;
+        for (int i = 0; i < u0.Length; i++)
+        {
+            ulong dd = d[i];
+            ulong hu1 = u1[i], hu0 = u0[i];
+            ulong r;
+            if ((u2[i] | u3[i] | a4[i]) == 0)
+            {
+                if (hu1 < dd)
+                {
+                    r = X86Base.X64.DivRem(hu0, hu1, dd).Remainder; // (hu1:hu0) % d in one DIV
+                }
+                else
+                {
+                    ulong rr = X86Base.X64.DivRem(hu1, 0UL, dd).Remainder; // hu1 % d
+                    r = X86Base.X64.DivRem(hu0, rr, dd).Remainder;
+                }
+            }
+            else
+            {
+                r = X86Base.X64.DivRem(u3[i], a4[i], dd).Remainder;
+                r = X86Base.X64.DivRem(u2[i], r, dd).Remainder;
+                r = X86Base.X64.DivRem(hu1, r, dd).Remainder;
+                r = X86Base.X64.DivRem(hu0, r, dd).Remainder;
+            }
+            acc ^= r;
+        }
+        return acc;
+    }
+}
+#pragma warning restore SYSLIB5004
 
 public readonly record struct DoubleUInt256(UInt256 A, UInt256 B)
 {

--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -705,18 +705,13 @@ public class ParseDecimalUnsigned : ParseUnsignedBenchmarkBase
     }
 }
 
-// In-process A/B for the ADDMOD-by-64-bit-modulus reduction (Remainder257By64BitsX86Base). The
-// current code issues four 64-bit hardware DivRems unconditionally (one per limb of the 257-bit
-// sum). x86 DIV is ~20-40 cycles, so when the sum fits in <=128 bits - the common case when ADDMOD's
-// operands are already reduced (x,y < m < 2^64), giving a sum < 2^65 - two or three of those divides
-// are pure waste (dividing zero high limbs). FastPath detects (u2|u3|carry)==0 and reduces the
-// 128-bit (u1:u0) value with one DivRem when u1<d, else two. The Full case (sum > 128 bits) takes the
-// same four-DivRem path in both, so it is a no-regression guard. Operands generated from a fixed seed.
+// In-process A/B for Remainder257By64BitsX86Base's fast path, which skips DivRems on zero high
+// limbs. Full is a no-regression guard: both paths take all four DivRems there.
 public enum SumWidth
 {
-    Small,   // x,y < 2^64  => sum < 2^65 (u1 in {0,1}); 1 DivRem on the fast path
-    Mid128,  // sum is a full 128-bit value (u1 large, < d not guaranteed); 2 DivRems on the fast path
-    Full,    // full 257-bit sum; 4 DivRems on both paths (regression guard)
+    Small,   // sum < 2^65; 1 DivRem on the fast path
+    Mid128,  // full 128-bit sum; 2 DivRems on the fast path
+    Full,    // full 257-bit sum; 4 DivRems on both paths
 }
 
 #pragma warning disable SYSLIB5004 // X86Base.X64.DivRem is [Experimental]; the library already uses it
@@ -737,6 +732,11 @@ public class AddModReduce64AB
     [GlobalSetup]
     public void Setup()
     {
+        if (!X86Base.X64.IsSupported)
+        {
+            throw new PlatformNotSupportedException($"{nameof(AddModReduce64AB)} requires x86-64 (X86Base.X64.DivRem).");
+        }
+
         _u0 = new ulong[N];
         _u1 = new ulong[N];
         _u2 = new ulong[N];

--- a/src/Nethermind.Int256/UInt256.DivideMod.cs
+++ b/src/Nethermind.Int256/UInt256.DivideMod.cs
@@ -526,12 +526,32 @@ public readonly partial struct UInt256
         ulong u2 = a.u2;
         ulong u3 = a.u3;
 
-        // Treat the top as a single 128-bit chunk (a4:u3) and take its remainder in ONE DivRem.
-        // This is valid as long as a4 < d. For a carry limb (0/1) and d>1, that's guaranteed.
-        ulong r = X86Base.X64.DivRem(u3, a4, d).Remainder;
-        r = X86Base.X64.DivRem(u2, r, d).Remainder;
-        r = X86Base.X64.DivRem(u1, r, d).Remainder;
-        r = X86Base.X64.DivRem(u0, r, d).Remainder;
+        ulong r;
+        if ((u2 | u3 | a4) == 0)
+        {
+            // The 257-bit sum actually fits in 128 bits (u1:u0). This is the common case when ADDMOD's
+            // operands are already reduced (x,y < m < 2^64 => sum < 2^65). x86 DIV is expensive
+            // (~20-40 cycles), so skip the two divides that would just reduce the zero high limbs.
+            if (u1 < d)
+            {
+                // u1 < d guarantees the quotient fits in 64 bits, so one DivRem yields (u1:u0) % d.
+                r = X86Base.X64.DivRem(u0, u1, d).Remainder;
+            }
+            else
+            {
+                ulong hi = X86Base.X64.DivRem(u1, 0UL, d).Remainder; // u1 % d (high half is zero)
+                r = X86Base.X64.DivRem(u0, hi, d).Remainder;
+            }
+        }
+        else
+        {
+            // Treat the top as a single 128-bit chunk (a4:u3) and take its remainder in ONE DivRem.
+            // This is valid as long as a4 < d. For a carry limb (0/1) and d>1, that's guaranteed.
+            r = X86Base.X64.DivRem(u3, a4, d).Remainder;
+            r = X86Base.X64.DivRem(u2, r, d).Remainder;
+            r = X86Base.X64.DivRem(u1, r, d).Remainder;
+            r = X86Base.X64.DivRem(u0, r, d).Remainder;
+        }
 
         rem = default;
         Unsafe.AsRef(in rem.u0) = r;

--- a/src/Nethermind.Int256/UInt256.DivideMod.cs
+++ b/src/Nethermind.Int256/UInt256.DivideMod.cs
@@ -529,17 +529,15 @@ public readonly partial struct UInt256
         ulong r;
         if ((u2 | u3 | a4) == 0)
         {
-            // The 257-bit sum actually fits in 128 bits (u1:u0). This is the common case when ADDMOD's
-            // operands are already reduced (x,y < m < 2^64 => sum < 2^65). x86 DIV is expensive
-            // (~20-40 cycles), so skip the two divides that would just reduce the zero high limbs.
+            // Sum fits in 128 bits (u1:u0) - the common ADDMOD case (x,y < m < 2^64). Skip the two
+            // divides that would just reduce the zero high limbs.
             if (u1 < d)
             {
-                // u1 < d guarantees the quotient fits in 64 bits, so one DivRem yields (u1:u0) % d.
                 r = X86Base.X64.DivRem(u0, u1, d).Remainder;
             }
             else
             {
-                ulong hi = X86Base.X64.DivRem(u1, 0UL, d).Remainder; // u1 % d (high half is zero)
+                ulong hi = X86Base.X64.DivRem(u1, 0UL, d).Remainder;
                 r = X86Base.X64.DivRem(u0, hi, d).Remainder;
             }
         }


### PR DESCRIPTION
## Summary

Adds a fast path to `Remainder257By64BitsX86Base` — the reduction `AddMod` uses when the modulus fits in 64 bits. The current code issues **four** 64-bit hardware `DivRem`s unconditionally (one per limb of the 257-bit sum `x + y`). When that sum fits in ≤128 bits, two or three of those divides just reduce zero high limbs and are pure waste.

## Why

`AddMod(x, y, m)` with `m.IsUint64` computes the 257-bit sum, then calls `Remainder257By64BitsX86Base`. The **common case** is operands already reduced (`x, y < m < 2^64`), giving a sum `< 2^65` — i.e. `u2 = u3 = carry = 0`. x86 `DIV` is ~20–40 cycles, so the two divides over the zero high limbs dominate the cost for nothing.

The fix detects `(u2 | u3 | carry) == 0` and reduces the 128-bit `(u1:u0)` value with **one** `DivRem` when `u1 < d` (the quotient provably fits in 64 bits), else **two**. The full 257-bit path is untouched, so wider sums are unaffected. This mirrors `MulModBy64Bits`, which already fast-reduces sub-2⁶⁴ operands.

## Benchmark (in-process A/B, Alder Lake i7-12700H)

Reducing the 5-limb sum by a 64-bit modulus, current vs fast path (`AddModReduce64AB`):

| Sum width | Current (4× DivRem) | Fast path | Speedup |
|---|---|---|---|
| `< 2^65` (reduced operands) | 15.34 ns | **4.10 ns** | **3.7× (−73%)** |
| 128-bit | 15.37 ns | **7.87 ns** | **2.0× (−49%)** |
| full 257-bit (regression guard) | 16.91 ns | 16.29 ns | no change |

## Scope & correctness

- **x86 only**: the `X86Base.X64` path. The portable reciprocal fallback (`Remainder257By64Bits`, used when `X86Base.X64` is unavailable, e.g. Arm) is unchanged — it already avoids hardware `DIV`.
- `DivRem(u0, u1, d)` is valid because `u1 < d` ⇒ quotient `< 2^64`; the `u1 ≥ d` sub-case does the standard two-step reduction.
- All **575,160** tests pass with AVX2 enabled and with intrinsics disabled. The `AddMod` ternary-ops suite already covers 64-bit moduli with both reduced (≤128-bit sum) and full-width operands.

## Honest impact note

`ADDMOD` is a relatively uncommon EVM opcode, and the 64-bit-modulus sub-case is a fraction of that — so this is a targeted micro-optimization, not a headline mainnet win. It removes a genuine inefficiency at zero regression and brings `ADDMOD`-small in line with `MULMOD`. (`ADD` was checked and left alone — its AVX2 path genuinely wins; `MOD` already fast-paths small dividends.)
