### PR TITLE
ADDMOD: skip wasted reductions in the portable 64-bit-modulus remainder (zk guest / ARM path)

### DIFF
--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -704,6 +704,71 @@ public class ParseDecimalUnsigned : ParseUnsignedBenchmarkBase
     }
 }
 
+// End-to-end AddMod with a 64-bit modulus across sum widths. Under the no-intrinsics job
+// X86Base is unavailable, so AddMod takes the portable Remainder257By64Bits path; the default
+// job takes the untouched x86 path and serves as a control.
+public enum ModSumWidth
+{
+    Small,   // x, y < m => sum fits one limb
+    Mid128,  // sum is a full 128-bit value
+    Full,    // full-width operands, small modulus
+}
+
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+public class AddModByUInt64Modulus
+{
+    private const int N = 1024;
+    private UInt256[] _x = null!;
+    private UInt256[] _y = null!;
+    private UInt256[] _m = null!;
+
+    [Params(ModSumWidth.Small, ModSumWidth.Mid128, ModSumWidth.Full)]
+    public ModSumWidth Width;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _x = new UInt256[N];
+        _y = new UInt256[N];
+        _m = new UInt256[N];
+        Random rnd = new(42);
+        for (int i = 0; i < N; i++)
+        {
+            ulong m = (ulong)rnd.NextInt64(2, long.MaxValue);
+            _m[i] = m;
+            switch (Width)
+            {
+                case ModSumWidth.Small:
+                    _x[i] = (ulong)rnd.NextInt64() % m;
+                    _y[i] = (ulong)rnd.NextInt64() % m;
+                    break;
+                case ModSumWidth.Mid128:
+                    _x[i] = new UInt256((ulong)rnd.NextInt64(), (ulong)rnd.NextInt64() >> 1, 0, 0);
+                    _y[i] = new UInt256((ulong)rnd.NextInt64(), (ulong)rnd.NextInt64() >> 1, 0, 0);
+                    break;
+                default:
+                    _x[i] = new UInt256((ulong)rnd.NextInt64(), (ulong)rnd.NextInt64(), (ulong)rnd.NextInt64(), (ulong)rnd.NextInt64());
+                    _y[i] = new UInt256((ulong)rnd.NextInt64(), (ulong)rnd.NextInt64(), (ulong)rnd.NextInt64(), (ulong)rnd.NextInt64());
+                    break;
+            }
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public ulong AddMod_UInt64Modulus()
+    {
+        UInt256[] x = _x, y = _y, m = _m;
+        ulong acc = 0;
+        for (int i = 0; i < x.Length; i++)
+        {
+            UInt256.AddMod(in x[i], in y[i], in m[i], out UInt256 res);
+            acc ^= (ulong)res;
+        }
+        return acc;
+    }
+}
+
 public readonly record struct DoubleUInt256(UInt256 A, UInt256 B)
 {
     public override readonly string ToString() => $"{A.BitLen} bits / {B.BitLen} bits";

--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -939,9 +939,10 @@ public class ParseDecimalUnsigned : ParseUnsignedBenchmarkBase
 // job takes the untouched x86 path and serves as a control.
 public enum ModSumWidth
 {
-    Small,   // x, y < m => sum fits one limb
-    Mid128,  // sum is a full 128-bit value
-    Full,    // full-width operands, small modulus
+    Small,    // x, y < m < 2^63 => sum fits one limb
+    CarryU1,  // x, y < m with the modulus MSB set => sum has u1 == 1
+    Mid128,   // sum is a full 128-bit value
+    Full,     // full-width operands, small modulus
 }
 
 [SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
@@ -953,7 +954,7 @@ public class AddModByUInt64Modulus
     private UInt256[] _y = null!;
     private UInt256[] _m = null!;
 
-    [Params(ModSumWidth.Small, ModSumWidth.Mid128, ModSumWidth.Full)]
+    [Params(ModSumWidth.Small, ModSumWidth.CarryU1, ModSumWidth.Mid128, ModSumWidth.Full)]
     public ModSumWidth Width;
 
     [GlobalSetup]
@@ -966,12 +967,16 @@ public class AddModByUInt64Modulus
         for (int i = 0; i < N; i++)
         {
             ulong m = (ulong)rnd.NextInt64(2, long.MaxValue);
-            _m[i] = m;
             switch (Width)
             {
                 case ModSumWidth.Small:
                     _x[i] = (ulong)rnd.NextInt64() % m;
                     _y[i] = (ulong)rnd.NextInt64() % m;
+                    break;
+                case ModSumWidth.CarryU1:
+                    m = 0x8000_0000_0000_0001UL | (ulong)rnd.NextInt64();
+                    _x[i] = m - 1;
+                    _y[i] = m - 1;
                     break;
                 case ModSumWidth.Mid128:
                     _x[i] = new UInt256((ulong)rnd.NextInt64(), (ulong)rnd.NextInt64() >> 1, 0, 0);
@@ -982,6 +987,7 @@ public class AddModByUInt64Modulus
                     _y[i] = new UInt256((ulong)rnd.NextInt64(), (ulong)rnd.NextInt64(), (ulong)rnd.NextInt64(), (ulong)rnd.NextInt64());
                     break;
             }
+            _m[i] = m;
         }
     }
 

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -662,6 +662,8 @@ public class UInt256Tests : UInt256TestsTemplate<UInt256>
             yield return (new UInt256(ulong.MaxValue, 0, 0, 0), 0, 7);
             yield return (new UInt256(ulong.MaxValue, 0, 0, 0), 0, ulong.MaxValue);
             // 128-bit sums: carry-only u1, large u1 below/above d, both s == 0 (d MSB set) and s > 0.
+            yield return (new UInt256(ulong.MaxValue, ulong.MaxValue, 0, 0), 0, 1);
+            yield return (new UInt256(ulong.MaxValue, ulong.MaxValue, 0, 0), 0, 2);
             yield return (new UInt256(3, 1, 0, 0), 0, 10);
             yield return (new UInt256(ulong.MaxValue, ulong.MaxValue, 0, 0), 0, 3);
             yield return (new UInt256(ulong.MaxValue, ulong.MaxValue, 0, 0), 0, ulong.MaxValue);

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using FluentAssertions;
@@ -646,6 +647,38 @@ public abstract class UInt256TestsTemplate<T> where T : IInteger<T>
 public class UInt256Tests : UInt256TestsTemplate<UInt256>
 {
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
+
+    public static IEnumerable<(UInt256 A, ulong A4, ulong D)> Remainder257By64BitsCases
+    {
+        get
+        {
+            // Single-limb sums: below and above the modulus.
+            yield return (new UInt256(5, 0, 0, 0), 0, 7);
+            yield return (new UInt256(ulong.MaxValue, 0, 0, 0), 0, 7);
+            yield return (new UInt256(ulong.MaxValue, 0, 0, 0), 0, ulong.MaxValue);
+            // 128-bit sums: carry-only u1, large u1 below/above d, both s == 0 (d MSB set) and s > 0.
+            yield return (new UInt256(3, 1, 0, 0), 0, 10);
+            yield return (new UInt256(ulong.MaxValue, ulong.MaxValue, 0, 0), 0, 3);
+            yield return (new UInt256(ulong.MaxValue, ulong.MaxValue, 0, 0), 0, ulong.MaxValue);
+            yield return (new UInt256(1, 2, 0, 0), 0, 0x8000_0000_0000_0001UL);
+            yield return (new UInt256(0x1234_5678_9abc_def0UL, 0xfedc_ba98_7654_3210UL, 0, 0), 0, 0xdead_beef_cafe_babeUL);
+            // Full-width sums, including the 257th bit.
+            yield return (new UInt256(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue), 1, 7);
+            yield return (new UInt256(1, 0, 0, ulong.MaxValue), 0, 0x8000_0000_0000_0000UL);
+            yield return (new UInt256(0, 0, 1, 0), 0, 2);
+        }
+    }
+
+    [TestCaseSource(nameof(Remainder257By64BitsCases))]
+    public void Remainder257By64Bits_Matches_BigInteger((UInt256 A, ulong A4, ulong D) test)
+    {
+        BigInteger dividend = ((BigInteger)test.A4 << 256) + (BigInteger)test.A;
+        BigInteger expected = dividend % test.D;
+
+        UInt256.Remainder257By64Bits(in test.A, test.A4, test.D, out UInt256 rem);
+
+        ((BigInteger)rem).Should().Be(expected);
+    }
 
     [Test]
     public virtual void Zero_is_min_value()

--- a/src/Nethermind.Int256/UInt256.DivideMod.cs
+++ b/src/Nethermind.Int256/UInt256.DivideMod.cs
@@ -466,16 +466,53 @@ public readonly partial struct UInt256
 
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void Remainder257By64Bits(in UInt256 a, ulong a4, ulong d, out UInt256 rem)
+    internal static void Remainder257By64Bits(in UInt256 a, ulong a4, ulong d, out UInt256 rem)
     {
         // Remainder of 5-limb value by 64-bit modulus.
         // Computes ((a4..a0 base 2^64) % d).
         Debug.Assert(d != 0);
         Debug.Assert(a4 <= 1);
 
+        ulong r;
+        if ((a.u1 | a.u2 | a.u3 | a4) == 0)
+        {
+            // Single-limb sum: one hardware remainder beats the reciprocal chain below.
+            rem = default;
+            Unsafe.AsRef(in rem.u0) = a.u0 < d ? a.u0 : a.u0 % d;
+            return;
+        }
+
         int s = BitOperations.LeadingZeroCount(d);
         ulong dn = (s != 0) ? (d << s) : d;       // normalised (msb set) if s>0
         ulong recip = Reciprocal2By1(dn);
+
+        if ((a.u2 | a.u3 | a4) == 0)
+        {
+            // The sum fits in 128 bits (u1:u0) - the common ADDMOD case with already-reduced
+            // operands. Normalise just the two low limbs; the bits shifted out of u1 seed the
+            // remainder (they are < 2^s <= dn, satisfying UDivRem2By1's r < d precondition).
+            ulong l0, l1;
+            if (s == 0)
+            {
+                r = 0;
+                l1 = a.u1;
+                l0 = a.u0;
+            }
+            else
+            {
+                int rs = 64 - s;
+                r = a.u1 >> rs;
+                l1 = (a.u1 << s) | (a.u0 >> rs);
+                l0 = a.u0 << s;
+            }
+
+            _ = UDivRem2By1(r, recip, dn, l1, out r);
+            _ = UDivRem2By1(r, recip, dn, l0, out r);
+
+            rem = default;
+            Unsafe.AsRef(in rem.u0) = (s == 0) ? r : (r >> s);
+            return;
+        }
 
         // Normalise dividend (we treat it as 6 limbs with top limb 0)
         ulong u0, u1, u2, u3, u4, u5;
@@ -501,7 +538,7 @@ public readonly partial struct UInt256
 
         // Horner-like remainder using exact 2-by-1 divisions:
         // r = (((((u5*b + u4)*b + u3)*b + u2)*b + u1)*b + u0) % dn
-        ulong r = 0;
+        r = 0;
         _ = UDivRem2By1(r, recip, dn, u5, out r);
         _ = UDivRem2By1(r, recip, dn, u4, out r);
         _ = UDivRem2By1(r, recip, dn, u3, out r);


### PR DESCRIPTION
## Summary

Follow-up to #93, which cut the wasted `DivRem`s in the **x86** ADDMOD reduction. This PR ports the same idea to the **portable** `Remainder257By64Bits` — the path executed wherever `X86Base.X64` is unavailable: RISC-V zk guests (the bflat-riscv64/Zisk NativeAOT build) and ARM hosts.

## Problem

The portable routine always ran full 6-limb normalization plus **six** `UDivRem2By1` reciprocal reductions, even when the 257-bit sum fits in one or two limbs — the common ADDMOD case with already-reduced operands (`x, y < m < 2^64`). Each reduction is a `Multiply64` chain, among the most expensive op classes in a zk proving-cost model.

## Change

Two fast paths, checked on **raw** limbs before normalization:

- **Single-limb sum** (`(u1|u2|u3|carry) == 0`): one hardware remainder (`remu` on rv64im, `udiv+msub` on ARM64) replaces the ~150-instruction `LZC + Reciprocal2By1 + 6×UDivRem2By1` chain — ~12x fewer instructions, zero table loads.
- **128-bit sum** (`(u2|u3|carry) == 0`): normalize just `u1:u0`; the bits shifted out of `u1` seed the remainder (they are `< 2^s ≤ dn`, satisfying `UDivRem2By1`'s `r < d` precondition), then two reductions instead of six — ~35% fewer instructions.

Full-width sums pay ~7-8 extra ALU ops for the two checks (~4-5% on that already-expensive path); that input class (unreduced ≥2^128 operand with a small modulus) is rare in practice.

x86-64 is unaffected — it dispatches to `Remainder257By64BitsX86Base` before this code.

## Why this matters (caller evidence)

`OpAddMod` routes straight to `UInt256.AddMod` (`EvmInstructions.Math3Param.cs`), so this is EVM ADDMOD opcode work in the zk guest, where the portable path is the only one compiled.

## Validation

- New `Remainder257By64Bits_Matches_BigInteger` oracle tests (11 cases) pin all three branches directly — including `s == 0` (modulus with MSB set), carry-only `u1`, `u1 ≥ d`, and the 257th bit. The routine is now `internal` (existing `InternalsVisibleTo` test-friend pattern) so the portable path is exercised even on x64 CI, where `AddMod` itself always takes the x86 branch.
- Full suite: 575,171 tests green.
- Adversarial verification additionally ran ~1,155 targeted edge cases plus 2,000,000 randomized edge-biased inputs against a `BigInteger` oracle across all three paths (incl. `carry=1`) — zero divergences. The 128-bit path is limb-for-limb identical to what the old 6-limb path computed for those inputs, so results are bitwise-equal, not just numerically equal.


## Benchmark

New `AddModByUInt64Modulus` benchmark: end-to-end `UInt256.AddMod` with a 64-bit modulus across sum widths. The `DOTNET_EnableHWIntrinsic=0` job disables `X86Base`, forcing the portable path this PR changes; the default job takes the untouched x86 path and serves as a control. i7-12700H (Alder Lake), .NET 10, `launchCount: 3`, cross-commit A/B (main `f228333` vs this branch):

**Portable path (no-intrinsics job) — the code a RISC-V zk guest / ARM host executes:**

| Width | main | PR | Δ |
|---|---:|---:|---:|
| Small (sum fits one limb) | 80.41 ns | 6.58 ns | **12.2x** |
| Mid128 (128-bit sum) | 66.35 ns | 33.43 ns | **2.0x** |
| Full (full-width sum, regression guard) | 66.00 ns | 64.88 ns | ~1.02x (within noise) |

**x86 path (default job, control — must be unchanged):**

| Width | main | PR |
|---|---:|---:|
| Small | 13.90 ns | 12.84 ns |
| Mid128 | 13.23 ns | 12.83 ns |
| Full | 13.30 ns | 14.21 ns |

The x64-no-intrinsics numbers are indicative for relative gain, not identical to guest cost ratios — on rv64ima (no Zbb) the removed reciprocal-multiply work is relatively more expensive, so the guest-side gain should be at least this large.
