### PR TITLE
Int256: top-bit sign test in operator<, limb-based IsZero/IsOne (EVM SLT/SGT path)

### DIFF
--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
@@ -701,6 +702,94 @@ public class ParseDecimalUnsigned : ParseUnsignedBenchmarkBase
     public bool TryParse_UInt256()
     {
         return UInt256.TryParse(Value, out _);
+    }
+}
+
+// In-process A/B for the Int256 signed-comparison preamble: master's Sign-based classification
+// (replicated below via the public surface) vs operator<'s top-bit test.
+public enum SignedCmpCase
+{
+    DifferSign,          // operands of opposite sign - decided by the preamble alone
+    SameSignDifferHigh,  // both negative, differ in the top limb
+    Equal,               // fully equal - full limb compare on both paths
+}
+
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
+public class SignedCompareAB
+{
+    private const int N = 1024;
+    private Int256[] _a = null!;
+    private Int256[] _b = null!;
+
+    [Params(SignedCmpCase.DifferSign, SignedCmpCase.SameSignDifferHigh, SignedCmpCase.Equal)]
+    public SignedCmpCase Case;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _a = new Int256[N];
+        _b = new Int256[N];
+        Random rnd = new(42);
+        for (int i = 0; i < N; i++)
+        {
+            ulong x0 = (ulong)rnd.NextInt64();
+            ulong x1 = (ulong)rnd.NextInt64();
+            ulong x2 = (ulong)rnd.NextInt64();
+            ulong x3 = (ulong)rnd.NextInt64() | 0x8000_0000_0000_0000UL;
+            _a[i] = new Int256(new UInt256(x0, x1, x2, x3));
+            _b[i] = Case switch
+            {
+                SignedCmpCase.DifferSign => new Int256(new UInt256(x0, x1, x2, x3 & ~0x8000_0000_0000_0000UL)),
+                SignedCmpCase.SameSignDifferHigh => new Int256(new UInt256(x0, x1, x2, x3 ^ 0x4000_0000_0000_0000UL)),
+                _ => _a[i],
+            };
+        }
+    }
+
+    // Master's operator< shape: full Sign for both operands, then the unsigned limb compare.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool LessThanSignBased(in Int256 z, in Int256 x)
+    {
+        int zSign = z.Sign;
+        int xSign = x.Sign;
+
+        if (zSign >= 0)
+        {
+            if (xSign < 0)
+            {
+                return false;
+            }
+        }
+        else if (xSign >= 0)
+        {
+            return true;
+        }
+
+        return Unsafe.As<Int256, UInt256>(ref Unsafe.AsRef(in z)) < Unsafe.As<Int256, UInt256>(ref Unsafe.AsRef(in x));
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = N)]
+    public int LessThan_SignBased()
+    {
+        Int256[] a = _a, b = _b;
+        int acc = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (LessThanSignBased(in a[i], in b[i])) acc++;
+        }
+        return acc;
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public int LessThan_TopBit()
+    {
+        Int256[] a = _a, b = _b;
+        int acc = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (a[i] < b[i]) acc++;
+        }
+        return acc;
     }
 }
 

--- a/src/Nethermind.Int256.Tests/Int256Tests.cs
+++ b/src/Nethermind.Int256.Tests/Int256Tests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;
@@ -84,5 +85,47 @@ public class Int256Tests : UInt256TestsTemplate<Int256>
             convertedValue.Should().BeEquivalentTo(expected);
         }
         catch (Exception e) when (e.GetType() == expectedException) { }
+    }
+
+    public static IEnumerable<(BigInteger, BigInteger)> CompareBoundaryCases
+    {
+        get
+        {
+            BigInteger min = -(BigInteger.One << 255);
+            BigInteger[] values = [min, min + 1, -2, -1, 0, 1, 2, TestNumbers.Int256Max];
+            foreach (BigInteger a in values)
+            {
+                foreach (BigInteger b in values)
+                {
+                    yield return (a, b);
+                }
+            }
+        }
+    }
+
+    [TestCaseSource(typeof(BinaryOps), nameof(BinaryOps.SignedTestCases))]
+    [TestCaseSource(nameof(CompareBoundaryCases))]
+    public void Compare_operators_match_BigInteger((BigInteger A, BigInteger B) test)
+    {
+        Int256 a = new(test.A);
+        Int256 b = new(test.B);
+
+        (a < b).Should().Be(test.A < test.B);
+        (a > b).Should().Be(test.A > test.B);
+        Math.Sign(a.CompareTo(b)).Should().Be(test.A.CompareTo(test.B));
+    }
+
+    [Test]
+    public void Is_zero_and_is_one_signed()
+    {
+        Int256.Zero.IsZero.Should().BeTrue();
+        Int256.One.IsZero.Should().BeFalse();
+        Int256.MinusOne.IsZero.Should().BeFalse();
+        new Int256(-(BigInteger.One << 255)).IsZero.Should().BeFalse();
+
+        Int256.One.IsOne.Should().BeTrue();
+        Int256.Zero.IsOne.Should().BeFalse();
+        Int256.MinusOne.IsOne.Should().BeFalse();
+        Int256.Max.IsOne.Should().BeFalse();
     }
 }

--- a/src/Nethermind.Int256.Tests/Int256Tests.cs
+++ b/src/Nethermind.Int256.Tests/Int256Tests.cs
@@ -112,7 +112,7 @@ public class Int256Tests : UInt256TestsTemplate<Int256>
 
         (a < b).Should().Be(test.A < test.B);
         (a > b).Should().Be(test.A > test.B);
-        Math.Sign(a.CompareTo(b)).Should().Be(test.A.CompareTo(test.B));
+        Math.Sign(a.CompareTo(b)).Should().Be(Math.Sign(test.A.CompareTo(test.B)));
     }
 
     [Test]

--- a/src/Nethermind.Int256/Int256.cs
+++ b/src/Nethermind.Int256/Int256.cs
@@ -536,9 +536,9 @@ public readonly struct Int256 : IEquatable<Int256>, IComparable, IComparable<Int
 
     public static bool operator !=(in Int256 a, in Int256 b) => !(a == b);
 
-    public bool IsZero => this == Zero;
+    public bool IsZero => _value.IsZero;
 
-    public bool IsOne => this == One;
+    public bool IsOne => _value.IsOne;
 
     public Int256 MaximalValue => Max;
 
@@ -553,19 +553,12 @@ public readonly struct Int256 : IEquatable<Int256>, IComparable, IComparable<Int
 
     public static bool operator <(in Int256 z, in Int256 x)
     {
-        int zSign = z.Sign;
-        int xSign = x.Sign;
-
-        if (zSign >= 0)
+        // If the sign bits differ, the negative operand is smaller; otherwise two's-complement
+        // order within the same sign class equals unsigned order of the raw bits.
+        bool zNeg = (long)z._value.u3 < 0;
+        if (zNeg != ((long)x._value.u3 < 0))
         {
-            if (xSign < 0)
-            {
-                return false;
-            }
-        }
-        else if (xSign >= 0)
-        {
-            return true;
+            return zNeg;
         }
 
         return z._value < x._value;

--- a/src/Nethermind.Int256/Int256.cs
+++ b/src/Nethermind.Int256/Int256.cs
@@ -551,12 +551,13 @@ public readonly struct Int256 : IEquatable<Int256>, IComparable, IComparable<Int
 
     public static explicit operator UInt256(Int256 z) => z._value;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator <(in Int256 z, in Int256 x)
     {
         // If the sign bits differ, the negative operand is smaller; otherwise two's-complement
         // order within the same sign class equals unsigned order of the raw bits.
-        bool zNeg = (long)z._value.u3 < 0;
-        if (zNeg != ((long)x._value.u3 < 0))
+        bool zNeg = unchecked((long)z._value.u3) < 0;
+        if (zNeg != (unchecked((long)x._value.u3) < 0))
         {
             return zNeg;
         }


### PR DESCRIPTION
## Summary

Scalar fast path for `Int256` signed comparison and cheaper `IsZero`/`IsOne`. These sit directly on EVM opcode paths: **SLT/SGT** go through `Int256.CompareTo` → `operator<` (`EvmInstructions.Math2Param.cs`, `OpSLt`/`OpSGt`), and the `Divide`/`Mod` internals used by **SDIV/SMOD** lean on the same accessors.

## Change

- **`operator<`**: previously computed full `Sign` for *both* operands — each an `IsZero` scan plus a `2^63` compare-and-select (~24-26 instructions, 8 limb loads of preamble) — only to classify them by sign. The top bit of `u3` gives the same classification (zero has it clear, matching `Sign >= 0`), and within a same-sign class two's-complement order equals unsigned order of the raw bits. New preamble: 2 loads + 2 compares + 1 branch, ~5x less work before the (unchanged) unsigned limb compare. No input class regresses — the new tests are a strict subset of the work the old code did.
- **`IsZero` / `IsOne`**: were `this == Zero` / `this == One` — a full equality against a static instance (~8 limb loads + static-field access). Now route to the `UInt256` limb checks (`(u0|u1|u2|u3) == 0` shape): ~4 loads, branchless, no static access.

Both changes are simpler scalar code, which is also what a RISC-V zk guest compiles and proves (all vector guards fold to false there).

## Validation

- Adversarial review found the pre-existing suite had **zero coverage of `Int256` comparison** — an inverted `operator<` passed all 575k tests. This PR adds `Compare_operators_match_BigInteger` (signed corpus cross-product + an explicit sign-boundary matrix including `-(2^255)`, `min+1`, `-2`, `-1`, `0`, `1`, `2`, `Int256Max`) asserting `<`, `>`, and `CompareTo` against the `BigInteger` oracle, plus `IsZero`/`IsOne` boundary tests. Mutation-checked: inverting the compare now fails 406 of the 548 new cases.
- Full suite: 575,709 tests green.

## Notes

- Trivial textual overlap with #90 (which adds `AggressiveInlining` *hints* to the same accessors; this PR changes their *bodies*) — whichever lands second rebases in seconds, and the changes compose.
- No overlap with #94: that PR touches `UInt256.cs` only.


## Benchmark

New `SignedCompareAB` in-process A/B (same pattern as #91/#93): master's `Sign`-based `operator<` shape replicated as the baseline vs the new top-bit operator, over 1024-element operand arrays per case. i7-12700H, .NET 10, `launchCount: 6`:

| Case | SignBased (master shape) | TopBit (this PR) | Ratio |
|---|---:|---:|---:|
| DifferSign (decided by preamble alone) | 2.349 ns | 1.109 ns | **0.47** |
| SameSignDifferHigh (both negative) | 4.348 ns | 2.644 ns | **0.62** |
| Equal (full limb compare both paths) | 3.446 ns | 2.232 ns | **0.66** |

The new form wins every operand class — expected, since the top-bit test is a strict subset of the work `Sign` did (it drops the two `IsZero` or-trees and the ±1 selects).
