### PR TITLE
Optimize MulMod for the maximum UInt256 modulus

### DIFF
--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -531,6 +531,23 @@ public class MultiplyMod64Targeted
     }
 }
 
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class MultiplyModMaxValueTargeted
+{
+    private static readonly UInt256 A =
+        new(0x89ABCDEF01234567, 0x76543210FEDCBA98, 0x1122334455667788, 0xFFEEDDCCBBAA0099);
+    private static readonly UInt256 B =
+        new(0x1020304050607080, 0x8877665544332211, 0xABCDEF0123456789, 0x9988776655443322);
+
+    [Benchmark]
+    public UInt256 MultiplyMod_UInt256()
+    {
+        UInt256.MultiplyMod(A, B, UInt256.MaxValue, out UInt256 res);
+        return res;
+    }
+}
+
 public class LeftShiftUnsigned : UnsignedIntTwoParamBenchmarkBase
 {
     [Benchmark(Baseline = true)]

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -686,6 +686,58 @@ public class UInt256Tests : UInt256TestsTemplate<UInt256>
     }
 
     [Test]
+    public void MultiplyMod_by_max_value_matches_BigInteger()
+    {
+        Random random = new(0);
+        byte[] operands = new byte[64];
+        UInt256[] boundaryValues =
+        [
+            default,
+            UInt256.One,
+            new UInt256(2),
+            new UInt256(ulong.MaxValue),
+            new UInt256(0, 1),
+            new UInt256(0, 0, 1),
+            UInt256.MaxValue - 1,
+            UInt256.MaxValue,
+        ];
+
+        foreach (UInt256 x in boundaryValues)
+        {
+            foreach (UInt256 y in boundaryValues)
+            {
+                AssertResult(in x, in y);
+            }
+        }
+
+        for (int i = 0; i < 4096; i++)
+        {
+            random.NextBytes(operands);
+            AssertResult(new UInt256(operands.AsSpan(0, 32)), new UInt256(operands.AsSpan(32, 32)));
+        }
+
+        static void AssertResult(in UInt256 x, in UInt256 y)
+        {
+            BigInteger expected = (BigInteger)x * (BigInteger)y % TestNumbers.UInt256Max;
+
+            UInt256.MultiplyMod(in x, in y, in UInt256.MaxValue, out UInt256 result);
+            ((BigInteger)result).Should().Be(expected);
+
+            UInt256 left = x;
+            UInt256 modulus = UInt256.MaxValue;
+            left.MultiplyMod(in y, in modulus, out left);
+            ((BigInteger)left).Should().Be(expected);
+
+            UInt256 right = y;
+            x.MultiplyMod(in right, in modulus, out right);
+            ((BigInteger)right).Should().Be(expected);
+
+            x.MultiplyMod(in y, in modulus, out modulus);
+            ((BigInteger)modulus).Should().Be(expected);
+        }
+    }
+
+    [Test]
     public virtual void ToBigEndian_And_Back()
     {
         byte[] bidEndian = convert(1000000000000000000).ToBigEndian();

--- a/src/Nethermind.Int256/UInt256.DivideMod.cs
+++ b/src/Nethermind.Int256/UInt256.DivideMod.cs
@@ -356,6 +356,23 @@ public readonly partial struct UInt256
             return;
         }
 
+        if (m.u3 == ulong.MaxValue && (m.u0 & m.u1 & m.u2) == ulong.MaxValue)
+        {
+            // 2^256 is congruent to 1 modulo 2^256 - 1, so fold the high half into the low half.
+            bool carry = AddOverflow(in lo, in hi, out res);
+            if (carry)
+            {
+                Add(in res, in One, out res);
+            }
+
+            if (res.u3 == ulong.MaxValue && (res.u0 & res.u1 & res.u2) == ulong.MaxValue)
+            {
+                res = default;
+            }
+
+            return;
+        }
+
         Remainder512By256Bits(in lo, in hi, in m, out res);
     }
 


### PR DESCRIPTION
## Summary

- Add a dedicated reduction path for modulus `2^256 - 1`.
- Fold the 512-bit product halves using the Mersenne modulus identity, including carry folding and canonical zero normalization.
- Add a focused benchmark for hardware-intrinsic and portable execution.
- Add boundary, deterministic random, and output-aliasing regression coverage.

## Performance

Matched local baseline/candidate measurements:

| Mode | Baseline | Candidate | Change |
|---|---:|---:|---:|
| Hardware intrinsics | 115.7 ns | 51.12 ns | -55.8% |
| Hardware intrinsics disabled | 212.5 ns | 68.97 ns | -67.5% |

A final run from the submitted commit measured 47.94 ns and 60.00 ns respectively.

## Validation

- Full test suite with hardware intrinsics enabled: 575,161 passed.
- Full test suite with hardware intrinsics disabled: 575,161 passed.
- Added boundary cross-products and 4,096 deterministic random operand pairs.
- Verified normal output and aliasing with the left operand, right operand, and modulus.
