### PR TITLE
Optimize scalar UInt256 multiplication

### DIFF
--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -295,6 +295,71 @@ public class MultiplyUnsigned : UnsignedTwoParamBenchmarkBase
     }
 }
 
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class MultiplyScalarTargeted
+{
+    private const int OperationCount = 256;
+    private DoubleUInt256[] _values = null!;
+
+    [Params("Full", "OneSmall", "Small", "ProductionMix")]
+    public string Shape { get; set; } = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = new DoubleUInt256[OperationCount];
+        for (int i = 0; i < _values.Length; i++)
+        {
+            ulong seed = (ulong)i * 0x9E3779B97F4A7C15UL + 0xD1B54A32D192ED03UL;
+            _values[i] = Shape switch
+            {
+                "Full" => CreateFull(seed),
+                "OneSmall" => CreateOneSmall(seed),
+                "Small" => new DoubleUInt256(seed | 2, (seed >> 1) | 2),
+                _ => (i % 100) switch
+                {
+                    < 31 => CreateOneSmall(seed),
+                    < 53 => CreateFull(seed),
+                    < 63 => Create192(seed),
+                    < 91 => Create128(seed),
+                    _ => new DoubleUInt256(seed | 2, (seed >> 1) | 2),
+                },
+            };
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationCount)]
+    public UInt256 Multiply()
+    {
+        UInt256 aggregate = default;
+        foreach (DoubleUInt256 value in _values)
+        {
+            UInt256 a = value.A;
+            UInt256 b = value.B;
+            UInt256.Multiply(in a, in b, out UInt256 result);
+            UInt256.Xor(in aggregate, in result, out aggregate);
+        }
+
+        return aggregate;
+    }
+
+    private static DoubleUInt256 Create128(ulong seed) =>
+        new(new UInt256(seed, seed ^ 0xA0761D6478BD642FUL), new UInt256(~seed, seed ^ 0xE7037ED1A0B428DBUL));
+
+    private static DoubleUInt256 Create192(ulong seed) =>
+        new(
+            new UInt256(seed, seed ^ 0xA0761D6478BD642FUL, seed ^ 0xE7037ED1A0B428DBUL),
+            new UInt256(~seed, seed ^ 0x8EBC6AF09C88C6E3UL, seed ^ 0x589965CC75374CC3UL));
+
+    private static DoubleUInt256 CreateFull(ulong seed) =>
+        new(
+            new UInt256(seed, seed ^ 0xA0761D6478BD642FUL, seed ^ 0xE7037ED1A0B428DBUL, seed ^ 0x8EBC6AF09C88C6E3UL),
+            new UInt256(~seed, seed ^ 0x589965CC75374CC3UL, seed ^ 0x1D8E4E27C47D124FUL, seed ^ 0xEB44ACCAB455D165UL));
+
+    private static DoubleUInt256 CreateOneSmall(ulong seed) =>
+        new(CreateFull(seed).A, (seed >> 1) | 2);
+}
+
 public class MultiplySigned : SignedTwoParamBenchmarkBase
 {
     [Benchmark(Baseline = true)]

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -686,6 +686,41 @@ public class UInt256Tests : UInt256TestsTemplate<UInt256>
     }
 
     [Test]
+    public void Multiply_random_values_match_BigInteger()
+    {
+        Random random = new(0);
+        byte[] operands = new byte[64];
+
+        for (int i = 0; i < 4096; i++)
+        {
+            random.NextBytes(operands);
+            UInt256 x = new(operands.AsSpan(0, 32));
+            UInt256 y = new(operands.AsSpan(32, 32));
+            UInt256 small = new((ulong)i * 0x9E3779B97F4A7C15UL + 1);
+
+            AssertResult(in x, in y);
+            AssertResult(in x, in small);
+            AssertResult(in small, in y);
+        }
+
+        static void AssertResult(in UInt256 x, in UInt256 y)
+        {
+            BigInteger expected = (BigInteger)x * (BigInteger)y % TestNumbers.TwoTo256;
+
+            UInt256.Multiply(in x, in y, out UInt256 result);
+            ((BigInteger)result).Should().Be(expected);
+
+            UInt256 left = x;
+            left.Multiply(in y, out left);
+            ((BigInteger)left).Should().Be(expected);
+
+            UInt256 right = y;
+            x.Multiply(in right, out right);
+            ((BigInteger)right).Should().Be(expected);
+        }
+    }
+
+    [Test]
     public virtual void ToBigEndian_And_Back()
     {
         byte[] bidEndian = convert(1000000000000000000).ToBigEndian();

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -501,7 +501,12 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
 
         ulong r3 = carry + h02 + h11 + h20
             + x0 * y3 + x1 * y2 + x2 * y1 + x3 * y0;
-        res = new UInt256(r0, r1, r2, r3);
+        Unsafe.SkipInit(out res);
+        ref ulong pr = ref Unsafe.As<UInt256, ulong>(ref res);
+        pr = r0;
+        Unsafe.Add(ref pr, 1) = r1;
+        Unsafe.Add(ref pr, 2) = r2;
+        Unsafe.Add(ref pr, 3) = r3;
     }
 
     [SkipLocalsInit]
@@ -523,7 +528,12 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
         carry = high + (r2 < low ? 1UL : 0UL);
 
         ulong r3 = x3 * y + carry;
-        res = new UInt256(r0, r1, r2, r3);
+        Unsafe.SkipInit(out res);
+        ref ulong pr = ref Unsafe.As<UInt256, ulong>(ref res);
+        pr = r0;
+        Unsafe.Add(ref pr, 1) = r1;
+        Unsafe.Add(ref pr, 2) = r2;
+        Unsafe.Add(ref pr, 3) = r3;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -466,34 +466,72 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
         ulong y1 = y.u1;
         ulong x2 = x.u2;
         ulong y2 = y.u2;
+        ulong x3 = x.u3;
+        ulong y3 = y.u3;
 
-        Unsafe.SkipInit(out res);
-        ref ulong pr = ref Unsafe.As<UInt256, ulong>(ref res);
+        if ((y1 | y2 | y3) == 0)
+        {
+            MultiplyByUInt64(in x, y0, out res);
+            return;
+        }
+        if ((x1 | x2 | x3) == 0)
+        {
+            MultiplyByUInt64(in y, x0, out res);
+            return;
+        }
 
-        ulong a0 = Multiply64(x0, y0, out pr);
+        ulong h00 = Multiply64(x0, y0, out ulong r0);
+        ulong h01 = Multiply64(x0, y1, out ulong l01);
+        ulong h10 = Multiply64(x1, y0, out ulong l10);
+        ulong h02 = Multiply64(x0, y2, out ulong l02);
+        ulong h11 = Multiply64(x1, y1, out ulong l11);
+        ulong h20 = Multiply64(x2, y0, out ulong l20);
 
-        // Column 1
-        ulong a1 = 0;
-        ulong a2 = 0;
-        MultiplyAddCarry(ref a0, ref a1, ref a2, x0, y1);
-        MultiplyAddCarry(ref a0, ref a1, ref a2, x1, y0);
-        Unsafe.Add(ref pr, 1) = a0;
+        ulong carry = 0;
+        ulong r1 = AddAndCountCarry(h00, l01, ref carry);
+        r1 = AddAndCountCarry(r1, l10, ref carry);
 
-        // carry into column 2 is (a2:a1) as a 128-bit value, aligned as (lo=a1, hi=a2)
+        ulong r2 = carry;
+        carry = 0;
+        r2 = AddAndCountCarry(r2, h01, ref carry);
+        r2 = AddAndCountCarry(r2, h10, ref carry);
+        r2 = AddAndCountCarry(r2, l02, ref carry);
+        r2 = AddAndCountCarry(r2, l11, ref carry);
+        r2 = AddAndCountCarry(r2, l20, ref carry);
 
-        // Column 2
-        a0 = a1;
-        a1 = a2;
-        a2 = 0;
-        MultiplyAddCarry(ref a0, ref a1, ref a2, x0, y2);
-        MultiplyAddCarry(ref a0, ref a1, ref a2, x1, y1);
-        MultiplyAddCarry(ref a0, ref a1, ref a2, x2, y0);
-        ulong s1 = x0 * y.u3 + x.u3 * y0;
-        ulong s0 = x1 * y2 + x2 * y1;
-        Unsafe.Add(ref pr, 2) = a0;
+        ulong r3 = carry + h02 + h11 + h20
+            + x0 * y3 + x1 * y2 + x2 * y1 + x3 * y0;
+        res = new UInt256(r0, r1, r2, r3);
+    }
 
-        // For r3 we only need the low 64 of the incoming carry, which is a1 here.
-        Unsafe.Add(ref pr, 3) = a1 + s0 + s1;
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void MultiplyByUInt64(in UInt256 x, ulong y, out UInt256 res)
+    {
+        ulong x0 = x.u0;
+        ulong x1 = x.u1;
+        ulong x2 = x.u2;
+        ulong x3 = x.u3;
+
+        ulong carry = Multiply64(x0, y, out ulong r0);
+        ulong high = Multiply64(x1, y, out ulong low);
+        ulong r1 = low + carry;
+        carry = high + (r1 < low ? 1UL : 0UL);
+
+        high = Multiply64(x2, y, out low);
+        ulong r2 = low + carry;
+        carry = high + (r2 < low ? 1UL : 0UL);
+
+        ulong r3 = x3 * y + carry;
+        res = new UInt256(r0, r1, r2, r3);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong AddAndCountCarry(ulong x, ulong y, ref ulong carry)
+    {
+        ulong sum = x + y;
+        carry += sum < x ? 1UL : 0UL;
+        return sum;
     }
 
     [SkipLocalsInit]


### PR DESCRIPTION
## Summary

- Replace the scalar multiplication accumulation with a direct column-based implementation.
- Add a four-product specialization when either operand fits in 64 bits.
- Keep the existing public API unchanged.
- Add workload-shape benchmarks and deterministic random/aliasing regression coverage.

## Performance

Matched local baseline/candidate measurements with tiered compilation disabled:

| Operand shape | Baseline | Candidate | Change |
|---|---:|---:|---:|
| Full-width | 23.686 ns | 20.263 ns | -14.5% |
| One 64-bit operand | 22.899 ns | 15.759 ns | -31.2% |
| Mixed distribution | 23.173 ns | 17.899 ns | -22.8% |
| Both 64-bit | 19.196 ns | 19.056 ns | -0.7% |

A final run from the submitted commit measured 17.98 ns, 14.66 ns, 17.74 ns, and 19.54 ns respectively.

## Validation

- Full test suite with hardware intrinsics enabled: 575,161 passed.
- Full test suite with hardware intrinsics disabled: 575,161 passed.
- Added 4,096 deterministic random iterations covering full-width multiplication and both operand orders for the 64-bit specialization.
- Verified normal and in-place output aliasing.
