### PR TITLE
Improve UInt256 hash performance

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,5 +10,6 @@
     <PackageVersion Include="NUnit" Version="4.5.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -649,6 +649,8 @@ public abstract class UInt256TestsTemplate<T> where T : IInteger<T>
 [Parallelizable(ParallelScope.All)]
 public class UInt256Tests : UInt256TestsTemplate<UInt256>
 {
+    private const int HashDistributionSampleCount = 4096;
+
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
 
     [Test]
@@ -928,10 +930,7 @@ public class UInt256Tests : UInt256TestsTemplate<UInt256>
             Assert.Ignore("The hardware-accelerated hash path is not available on this CPU.");
         }
 
-        const int sampleCount = 4096;
-        HashSet<int> hashes = new(sampleCount);
-
-        for (int value = 0; value < sampleCount; value++)
+        AssertHashCodesAreDistributed(value =>
         {
             Vector128<byte> second = Vector128.Create((uint)value, 0u, 0u, 0u).AsByte();
             Vector128<byte> first = AesRound(second);
@@ -941,16 +940,93 @@ public class UInt256Tests : UInt256TestsTemplate<UInt256>
                 second.AsUInt64().GetElement(0),
                 second.AsUInt64().GetElement(1));
 
-            hashes.Add(input.GetHashCode());
-        }
-
-        Assert.That(hashes.Count, Is.GreaterThan(sampleCount - 32),
-            $"fast-path inputs produced {hashes.Count}/{sampleCount} distinct hashes");
+            return input.GetHashCode();
+        }, "fast path");
 
         static Vector128<byte> AesRound(Vector128<byte> state)
             => x64.Aes.IsSupported
                 ? x64.Aes.Encrypt(state, Vector128<byte>.Zero)
                 : Arm.Aes.MixColumns(Arm.Aes.Encrypt(state, Vector128<byte>.Zero));
+    }
+
+    [TestCase(0u)]
+    [TestCase(1u)]
+    [TestCase(0xDEADBEEFu)]
+    public void GetHashCode_DeterministicFallbackMaintainsDistribution(uint seed)
+    {
+        AssertHashCodesAreDistributed(value =>
+        {
+            ulong first = (uint)value;
+            ulong third = SolveCrcInput(BitOperations.Crc32C(0u, first));
+            return new UInt256(first, 0, third, 0).GetCrcHashCode(seed);
+        }, $"deterministic fallback for seed {seed}");
+    }
+
+    [TestCase(0L)]
+    [TestCase(1L)]
+    [TestCase(0x00000000DEADBEEFL)]
+    public void GetHashCode_RandomizedFallbackMaintainsDistribution(long seed)
+        => AssertHashCodesAreDistributed(
+            value => new UInt256(0, 0, 0, (uint)value).GetXxHashCode(seed),
+            $"randomized fallback for seed {seed}");
+
+    private static void AssertHashCodesAreDistributed(Func<int, int> getHash, string context)
+    {
+        HashSet<int> hashes = new(HashDistributionSampleCount);
+        for (int value = 0; value < HashDistributionSampleCount; value++)
+        {
+            hashes.Add(getHash(value));
+        }
+
+        Assert.That(hashes.Count, Is.GreaterThan(HashDistributionSampleCount - 32),
+            $"{context} produced {hashes.Count}/{HashDistributionSampleCount} distinct hashes");
+    }
+
+    private static ulong SolveCrcInput(uint target)
+    {
+        Span<uint> pivotBasis = stackalloc uint[32];
+        Span<ulong> pivotSource = stackalloc ulong[32];
+        pivotBasis.Clear();
+        ulong dependentInput = 0;
+
+        for (int i = 0; i < 64; i++)
+        {
+            uint basis = BitOperations.Crc32C(0u, 1UL << i);
+            ulong source = 1UL << i;
+            while (basis != 0)
+            {
+                int column = BitOperations.TrailingZeroCount(basis);
+                if (pivotBasis[column] == 0)
+                {
+                    pivotBasis[column] = basis;
+                    pivotSource[column] = source;
+                    break;
+                }
+
+                basis ^= pivotBasis[column];
+                source ^= pivotSource[column];
+            }
+
+            if (basis == 0 && dependentInput == 0)
+            {
+                dependentInput = source;
+            }
+        }
+
+        if (target == 0)
+        {
+            return dependentInput;
+        }
+
+        ulong input = 0;
+        while (target != 0)
+        {
+            int column = BitOperations.TrailingZeroCount(target);
+            target ^= pivotBasis[column];
+            input ^= pivotSource[column];
+        }
+
+        return input;
     }
 
     [NonParallelizable]

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.Intrinsics;
 using FluentAssertions;
 using NUnit.Framework;
+using Arm = System.Runtime.Intrinsics.Arm;
+using x64 = System.Runtime.Intrinsics.X86;
 
 namespace Nethermind.Int256.Test;
 
@@ -914,6 +918,39 @@ public class UInt256Tests : UInt256TestsTemplate<UInt256>
             (uint256a >= b).Should().Be(test.A >= b);
             (uint256a == b).Should().Be(test.A == b);
         }
+    }
+
+    [Test]
+    public void GetHashCode_FastPathMaintainsDistribution()
+    {
+        if (!x64.Aes.IsSupported && !Arm.Aes.IsSupported)
+        {
+            Assert.Ignore("The hardware-accelerated hash path is not available on this CPU.");
+        }
+
+        const int sampleCount = 4096;
+        HashSet<int> hashes = new(sampleCount);
+
+        for (int value = 0; value < sampleCount; value++)
+        {
+            Vector128<byte> second = Vector128.Create((uint)value, 0u, 0u, 0u).AsByte();
+            Vector128<byte> first = AesRound(second);
+            UInt256 input = new(
+                first.AsUInt64().GetElement(0),
+                first.AsUInt64().GetElement(1),
+                second.AsUInt64().GetElement(0),
+                second.AsUInt64().GetElement(1));
+
+            hashes.Add(input.GetHashCode());
+        }
+
+        Assert.That(hashes.Count, Is.GreaterThan(sampleCount - 32),
+            $"fast-path inputs produced {hashes.Count}/{sampleCount} distinct hashes");
+
+        static Vector128<byte> AesRound(Vector128<byte> state)
+            => x64.Aes.IsSupported
+                ? x64.Aes.Encrypt(state, Vector128<byte>.Zero)
+                : Arm.Aes.MixColumns(Arm.Aes.Encrypt(state, Vector128<byte>.Zero));
     }
 
     [NonParallelizable]

--- a/src/Nethermind.Int256/Nethermind.Int256.csproj
+++ b/src/Nethermind.Int256/Nethermind.Int256.csproj
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO.Hashing;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -27,15 +28,19 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     // one node they will not be the same on another node or across a restart so hash collision cannot be used to degrade
     // the performance of the network as a whole.
     // Constant by default for zkVM-compatibility -- subject to change in the near feature
-    private static readonly uint _hashSeed = UseHashCodeRandomizer
+    private static readonly bool _useHashCodeRandomizer = UseHashCodeRandomizer;
+    private static readonly uint _hashSeed = _useHashCodeRandomizer
         ? (uint)RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue)
         : 2098026241U; // just a random prime number
-    private static readonly ulong _aesHashSeed0 = UseHashCodeRandomizer
+    private static readonly ulong _aesHashSeed0 = _useHashCodeRandomizer
         ? CreateHashSeed()
         : 0x1F83D9ABFB41BD6BUL;
-    private static readonly ulong _aesHashSeed1 = UseHashCodeRandomizer
+    private static readonly ulong _aesHashSeed1 = _useHashCodeRandomizer
         ? CreateHashSeed()
         : 0x5BE0CD19137E2179UL;
+    private static readonly long _xxHashSeed = _useHashCodeRandomizer
+        ? unchecked((long)CreateHashSeed())
+        : 0;
 
     [FeatureSwitchDefinition("Nethermind.Int256.UseHashCodeRandomizer")]
     public static bool UseHashCodeRandomizer => AppContext.TryGetSwitch("Nethermind.Int256.UseHashCodeRandomizer", out var useHashCodeRandomizer) && useHashCodeRandomizer;
@@ -1405,7 +1410,22 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
             return FoldHash(MumFold(mixed));
         }
 
-        uint seed = _hashSeed;
+        return _useHashCodeRandomizer
+            ? GetXxHashCode(_xxHashSeed)
+            : GetCrcHashCode(unchecked(_hashSeed + 32u));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly int GetXxHashCode(long seed)
+    {
+        ref byte start = ref Unsafe.As<ulong, byte>(ref Unsafe.AsRef(in u0));
+        ulong hash = XxHash3.HashToUInt64(MemoryMarshal.CreateReadOnlySpan(ref start, 32), seed);
+        return FoldHash((long)hash);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly int GetCrcHashCode(uint seed)
+    {
         ulong hash0 = BitOperations.Crc32C(seed, u0);
         ulong hash1 = BitOperations.Crc32C(seed ^ 0x9E3779B9u, u1);
         ulong hash2 = BitOperations.Crc32C(seed ^ 0x85EBCA6Bu, u2);

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System;
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
@@ -29,9 +30,23 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     private static readonly uint _hashSeed = UseHashCodeRandomizer
         ? (uint)RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue)
         : 2098026241U; // just a random prime number
+    private static readonly ulong _aesHashSeed0 = UseHashCodeRandomizer
+        ? CreateHashSeed()
+        : 0x1F83D9ABFB41BD6BUL;
+    private static readonly ulong _aesHashSeed1 = UseHashCodeRandomizer
+        ? CreateHashSeed()
+        : 0x5BE0CD19137E2179UL;
 
     [FeatureSwitchDefinition("Nethermind.Int256.UseHashCodeRandomizer")]
     public static bool UseHashCodeRandomizer => AppContext.TryGetSwitch("Nethermind.Int256.UseHashCodeRandomizer", out var useHashCodeRandomizer) && useHashCodeRandomizer;
+
+    [SkipLocalsInit]
+    private static ulong CreateHashSeed()
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+        RandomNumberGenerator.Fill(bytes);
+        return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+    }
 
     public static readonly UInt256 Zero = 0ul;
     public static readonly UInt256 One = 1ul;
@@ -1375,56 +1390,53 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     public override bool Equals(object? obj) => obj is UInt256 other && Equals(other);
 
     [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly override int GetHashCode()
     {
         // Very fast hardware accelerated non-cryptographic hash function
         uint seed = _hashSeed;
 
-        if (x64.Aes.IsSupported)
+        if (x64.Aes.IsSupported || Arm.Aes.IsSupported)
         {
             Vector128<byte> key = Unsafe.As<ulong, Vector128<byte>>(ref Unsafe.AsRef(in u0));
             Vector128<byte> data = Unsafe.As<ulong, Vector128<byte>>(ref Unsafe.AsRef(in u2));
-            // Mix in the instance-random seed
-            key ^= Vector128.CreateScalar(seed).AsByte();
-            // Single AESENC is a powerful mixer - 4 cycles, full diffusion
-            Vector128<byte> mixed = x64.Aes.Encrypt(data, key);
-            ulong compressed = mixed.AsUInt64().GetElement(0) ^ mixed.AsUInt64().GetElement(1);
-            return (int)(uint)(compressed ^ (compressed >> 32));
-        }
-        else if (Arm.Aes.IsSupported)
-        {
-            Vector128<byte> key = Unsafe.As<ulong, Vector128<byte>>(ref Unsafe.AsRef(in u0));
-            Vector128<byte> data = Unsafe.As<ulong, Vector128<byte>>(ref Unsafe.AsRef(in u2));
-            // Mix in the instance-random seed
-            key ^= Vector128.CreateScalar(seed).AsByte();
-            // ARM needs explicit MixColumns for equivalent diffusion
-            Vector128<byte> mixed = Arm.Aes.MixColumns(Arm.Aes.Encrypt(data, key));
-            ulong compressed = mixed.AsUInt64().GetElement(0) ^ mixed.AsUInt64().GetElement(1);
-            return (int)(uint)(compressed ^ (compressed >> 32));
+            key ^= Vector128.Create(_aesHashSeed0, _aesHashSeed1).AsByte();
+            // Two rounds maintain good distribution across the accelerated path.
+            Vector128<byte> mixed = HashAesRound(data, key);
+            mixed = HashAesRound(mixed, key);
+            return FoldHash(MumFold(mixed));
         }
 
-        uint hash0 = BitOperations.Crc32C(seed, u0);
-        uint hash1 = BitOperations.Crc32C(seed ^ 0x9E3779B9u, u1);
-        uint hash2 = BitOperations.Crc32C(seed ^ 0x85EBCA6Bu, u2);
-        uint hash3 = BitOperations.Crc32C(seed ^ 0xC2B2AE35u, u3);
+        ulong hash0 = BitOperations.Crc32C(seed, u0);
+        ulong hash1 = BitOperations.Crc32C(seed ^ 0x9E3779B9u, u1);
+        ulong hash2 = BitOperations.Crc32C(seed ^ 0x85EBCA6Bu, u2);
+        ulong hash3 = BitOperations.Crc32C(seed ^ 0xC2B2AE35u, u3);
+        return FoldHash(MumFold(hash0 | (hash1 << 32), hash2 | (hash3 << 32)));
+    }
 
-        hash0 += BitOperations.RotateLeft(hash1, 11);
-        hash2 = BitOperations.RotateLeft(hash2, 17) + BitOperations.RotateLeft(hash3, 23);
-        uint hash = hash2 + hash0;
-        return FinalMix(hash);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<byte> HashAesRound(Vector128<byte> state, Vector128<byte> roundKey)
+        => x64.Aes.IsSupported
+            ? x64.Aes.Encrypt(state, roundKey)
+            // Keep the round key outside AESE so state and roundKey have distinct roles in the mixer.
+            : Arm.Aes.MixColumns(Arm.Aes.Encrypt(state, Vector128<byte>.Zero)) ^ roundKey;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static int FinalMix(uint x)
-        {
-            // A tiny finaliser to improve avalanche:
-            // - xor-fold high bits down
-            // - multiply by an odd constant to spread changes across bits
-            // - xor-fold again to propagate the multiply result
-            x ^= x >> 16;
-            x *= 0x9E3779B1u;
-            x ^= x >> 16;
-            return (int)x;
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long MumFold(ulong a, ulong b)
+    {
+        ulong low = Math.BigMul(a ^ 0x9E3779B97F4A7C15UL, b ^ 0xBF58476D1CE4E5B9UL, out ulong high);
+        return (long)(low ^ high);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long MumFold(Vector128<byte> mixed)
+        => MumFold(mixed.AsUInt64().GetElement(0), mixed.AsUInt64().GetElement(1));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int FoldHash(long hash)
+    {
+        ulong value = (ulong)hash;
+        return (int)(value ^ (value >> 32));
     }
 
     public ulong this[int index] => index switch

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1394,8 +1394,6 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
     public readonly override int GetHashCode()
     {
         // Very fast hardware accelerated non-cryptographic hash function
-        uint seed = _hashSeed;
-
         if (x64.Aes.IsSupported || Arm.Aes.IsSupported)
         {
             Vector128<byte> key = Unsafe.As<ulong, Vector128<byte>>(ref Unsafe.AsRef(in u0));
@@ -1407,6 +1405,7 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
             return FoldHash(MumFold(mixed));
         }
 
+        uint seed = _hashSeed;
         ulong hash0 = BitOperations.Crc32C(seed, u0);
         ulong hash1 = BitOperations.Crc32C(seed ^ 0x9E3779B9u, u1);
         ulong hash2 = BitOperations.Crc32C(seed ^ 0x85EBCA6Bu, u2);


### PR DESCRIPTION
## Summary

- refine the hardware-accelerated `UInt256.GetHashCode` mixing path
- align fixed-size hash finalization and fallback selection across randomized and deterministic runtime modes
- add coverage for accelerated and fallback hash distribution

## Validation

- focused hash-path tests: 7 passed
- Release test suite: 575,716 passed
- Release test suite with hardware intrinsics disabled: 575,715 passed, 1 hardware-specific test skipped
- `dotnet pack`: passed
- `dotnet format --verify-no-changes`: passed
- `git diff --check`: passed