### PR TITLE
perf: accelerate 32-byte big-endian conversion on ARM64; add ARM CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,10 @@
 name: Benchmark
 
 on:
+  # Temporary: lets the workflow run before it lands on main (workflow_dispatch
+  # only resolves workflows present on the default branch). Remove before merge.
+  push:
+    branches: [perf/arm-simd-parity]
   workflow_dispatch:
     inputs:
       runner:
@@ -24,11 +28,12 @@ jobs:
   benchmark:
     name: Benchmark (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ inputs.max-minutes }}
+    # Inputs are empty on push events; fall back to the dispatch defaults.
+    timeout-minutes: ${{ inputs.max-minutes || 10 }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(inputs.runner == 'both' && '["ubuntu-latest","ubuntu-24.04-arm"]' || format('["{0}"]', inputs.runner)) }}
+        os: ${{ fromJSON((inputs.runner || 'both') == 'both' && '["ubuntu-latest","ubuntu-24.04-arm"]' || format('["{0}"]', inputs.runner)) }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -39,7 +44,7 @@ jobs:
       - name: Run benchmarks
         working-directory: src/Nethermind.Int256.Benchmark
         env:
-          BDN_FILTER: ${{ inputs.filter }}
+          BDN_FILTER: ${{ inputs.filter || '*ByteSwapBench*' }}
         run: >-
           dotnet run -c release --
           --filter "$BDN_FILTER"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,9 +38,11 @@ jobs:
 
       - name: Run benchmarks
         working-directory: src/Nethermind.Int256.Benchmark
+        env:
+          BDN_FILTER: ${{ inputs.filter }}
         run: >-
           dotnet run -c release --
-          --filter '${{ inputs.filter }}'
+          --filter "$BDN_FILTER"
           --job short
           --memory
           --exporters GitHub

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,66 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to benchmark on
+        default: ubuntu-24.04-arm
+        type: choice
+        options:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - both
+      filter:
+        description: BenchmarkDotNet --filter glob. Keep the suite small — ARM runners have 4 vCPUs. (ToBigEndianAB is x86-only.)
+        default: '*ByteSwapBench*'
+        type: string
+      max-minutes:
+        description: Kill the job after this many minutes if it has not finished
+        default: 10
+        type: number
+
+jobs:
+  benchmark:
+    name: Benchmark (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ inputs.max-minutes }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.runner == 'both' && '["ubuntu-latest","ubuntu-24.04-arm"]' || format('["{0}"]', inputs.runner)) }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v6
+
+      - name: Run benchmarks
+        working-directory: src/Nethermind.Int256.Benchmark
+        run: >-
+          dotnet run -c release --
+          --filter '${{ inputs.filter }}'
+          --job short
+          --memory
+          --exporters GitHub
+          --stopOnFirstError
+
+      - name: Publish results to job summary
+        if: always()
+        working-directory: src/Nethermind.Int256.Benchmark
+        run: |
+          echo "## Benchmark results (${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
+          if compgen -G "BenchmarkDotNet.Artifacts/results/*-report-github.md" > /dev/null; then
+            cat BenchmarkDotNet.Artifacts/results/*-report-github.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No benchmark results were produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload result artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ matrix.os }}
+          path: src/Nethermind.Int256.Benchmark/BenchmarkDotNet.Artifacts/results/
+          if-no-files-found: ignore

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -73,6 +73,17 @@ jobs:
             avx2: NoAvx2
             variant: zkevm
 
+          # linux-arm64: validates the AdvSimd paths on the production ARM target
+          # (the AVX2/AVX-512 env toggles are no-ops there).
+          - os: ubuntu-24.04-arm
+            build-config: release
+            intrinsics: HWIntrinsics
+            avx2: NoAvx2
+          - os: ubuntu-24.04-arm
+            build-config: release
+            intrinsics: NoHWIntrinsics
+            avx2: NoAvx2
+
     env:
       DOTNET_EnableAVX2: ${{ matrix.avx2 == 'NoAvx2' && '0' || '1' }}
       DOTNET_EnableHWIntrinsic: ${{ matrix.intrinsics == 'NoHWIntrinsics' && '0' || '1' }}

--- a/src/Nethermind.Int256.Benchmark/ByteSwapBench.cs
+++ b/src/Nethermind.Int256.Benchmark/ByteSwapBench.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using BenchmarkDotNet.Attributes;
+
+namespace Nethermind.Int256.Benchmark;
+
+/// <summary>
+/// Platform-neutral benchmark for the 32-byte big-endian read/write paths
+/// (AVX2/AVX-512 on x86, AdvSimd on ARM64, scalar otherwise).
+/// </summary>
+/// <remarks>
+/// Unlike <c>ToBigEndianAB</c>, whose setup throws without AVX2, this class runs on every ISA,
+/// so it is safe for the ARM benchmark CI suite (<c>--filter '*ByteSwapBench*'</c>).
+/// </remarks>
+public class ByteSwapBench
+{
+    private const int N = 16;
+
+    private byte[] _bigEndian = [];
+    private readonly byte[] _target = new byte[32];
+    private UInt256 _value;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _bigEndian = new byte[32];
+        for (int i = 0; i < _bigEndian.Length; i++)
+        {
+            _bigEndian[i] = (byte)(0xC0 + i);
+        }
+        _value = new UInt256(_bigEndian, isBigEndian: true);
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public UInt256 FromBigEndian()
+    {
+        UInt256 acc = default;
+        for (int i = 0; i < N; i++)
+        {
+            acc ^= new UInt256(_bigEndian, isBigEndian: true);
+        }
+        return acc;
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public void ToBigEndian()
+    {
+        for (int i = 0; i < N; i++)
+        {
+            _value.ToBigEndian(_target);
+        }
+    }
+}

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -1279,6 +1279,27 @@ public partial class UInt256Tests : UInt256TestsTemplate<UInt256>
         target.ToArray().Should().Equal(expected.ToArray());
     }
 
+    // 32 distinct byte values make any within-limb reversal or half/lane swap in the vectorized
+    // big-endian read/write paths (AVX2/AVX-512 on x86, AdvSimd on ARM64) visible byte-by-byte.
+    [Test]
+    public void BigEndian_Ctor_And_ToBigEndian_RoundTrip_Distinct_Bytes()
+    {
+        byte[] bigEndian = new byte[32];
+        for (int i = 0; i < bigEndian.Length; i++)
+        {
+            bigEndian[i] = (byte)(0xC0 + i);
+        }
+
+        UInt256 value = new(bigEndian, isBigEndian: true);
+
+        BigInteger expected = new(bigEndian, isUnsigned: true, isBigEndian: true);
+        ((BigInteger)value).Should().Be(expected);
+
+        Span<byte> written = stackalloc byte[32];
+        value.ToBigEndian(written);
+        written.ToArray().Should().Equal(bigEndian);
+    }
+
     // The 20-byte (address) overload writes the low 20 bytes of the 32-byte big-endian form.
     [TestCaseSource(nameof(ToBigEndianValues))]
     public void ToBigEndian_Span20_Matches_Low20Bytes(BigInteger value)

--- a/src/Nethermind.Int256/UInt256.Conversions.cs
+++ b/src/Nethermind.Int256/UInt256.Conversions.cs
@@ -8,6 +8,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace Nethermind.Int256;
@@ -126,6 +127,15 @@ public readonly partial struct UInt256
                     Vector256<ulong> permute = Avx2.Permute4x64(convert.AsUInt64(), 0b_01_00_11_10);
                     Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(target), permute);
                 }
+            }
+            else if (AdvSimd.Arm64.IsSupported)
+            {
+                // Mirror of the big-endian read ctor: REV64 + EXT #8 per half, halves stored swapped.
+                Vector128<ulong> reversedLower = AdvSimd.ReverseElement8(Unsafe.As<ulong, Vector128<ulong>>(ref Unsafe.AsRef(in u0)));
+                Vector128<ulong> reversedUpper = AdvSimd.ReverseElement8(Unsafe.As<ulong, Vector128<ulong>>(ref Unsafe.AsRef(in u2)));
+                ref byte dst = ref MemoryMarshal.GetReference(target);
+                AdvSimd.ExtractVector128(reversedUpper, reversedUpper, 1).AsByte().StoreUnsafe(ref dst);
+                AdvSimd.ExtractVector128(reversedLower, reversedLower, 1).AsByte().StoreUnsafe(ref dst, 16);
             }
             else
             {

--- a/src/Nethermind.Int256/UInt256.Ctors.cs
+++ b/src/Nethermind.Int256/UInt256.Ctors.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace Nethermind.Int256;
@@ -79,6 +80,20 @@ public readonly partial struct UInt256
                         Vector256<ulong> permute = Avx2.Permute4x64(Unsafe.As<Vector256<byte>, Vector256<ulong>>(ref convert), 0b_01_00_11_10);
                         Unsafe.As<ulong, Vector256<ulong>>(ref u0) = permute;
                     }
+                }
+                else if (AdvSimd.Arm64.IsSupported)
+                {
+                    Unsafe.SkipInit(out u0);
+                    Unsafe.SkipInit(out u1);
+                    Unsafe.SkipInit(out u2);
+                    Unsafe.SkipInit(out u3);
+                    // Full 32-byte reversal: REV64 reverses bytes within each 64-bit lane, EXT #8
+                    // swaps the lanes, and the two 16-byte halves swap places (u0:u1 <- high half).
+                    ref byte src = ref MemoryMarshal.GetReference(bytes);
+                    Vector128<ulong> reversedLower = AdvSimd.ReverseElement8(Vector128.LoadUnsafe(ref src).AsUInt64());
+                    Vector128<ulong> reversedUpper = AdvSimd.ReverseElement8(Vector128.LoadUnsafe(ref src, 16).AsUInt64());
+                    Unsafe.As<ulong, Vector128<ulong>>(ref u0) = AdvSimd.ExtractVector128(reversedUpper, reversedUpper, 1);
+                    Unsafe.As<ulong, Vector128<ulong>>(ref u2) = AdvSimd.ExtractVector128(reversedLower, reversedLower, 1);
                 }
                 else
                 {


### PR DESCRIPTION
## Changes

On linux-arm64 the AVX2-gated fast paths in the 32-byte big-endian conversions fall through to scalar `ReadUInt64BigEndian`/`WriteUInt64BigEndian` loops. This PR adds an `AdvSimd` branch (REV64 + EXT #8 per 16-byte half, halves stored swapped) between the AVX2 path and the scalar fallback — the library-level twin of NethermindEth/nethermind#12798:

- `UInt256(ReadOnlySpan<byte>, isBigEndian: true)` — every RLP/JSON-RPC UInt256 decode in the client
- `ToBigEndian(Span<byte>)` (32-byte path) — storage-key derivation, RLP encode, hex serialization

x86 and scalar paths are byte-for-byte untouched; both files compile into the std and zkevm variants (`AdvSimd.Arm64.IsSupported` folds to false off ARM).

## Measured on GitHub's ARM runners (Cobalt 100, `ubuntu-24.04-arm`)

| method | scalar (main) | NEON (this PR) | delta |
|---|---|---|---|
| `FromBigEndian` (BE ctor) | 3.418 ns | 2.469 ns | **−27.8%** |
| `ToBigEndian` | 1.379 ns | 0.903 ns | **−34.5%** |

Runs: [treatment](https://github.com/NethermindEth/int256/actions/runs/32221529196) / [scalar baseline](https://github.com/NethermindEth/int256/actions/runs/32221824140). The x64 leg of the same runs acts as an A/A control (AVX2 path unchanged). Within-run StdDev on the homogeneous ARM fleet is ~0.005 ns.

## CI

- `test-publish.yml`: two `ubuntu-24.04-arm` matrix rows (free for public repos) — `dotnet test` now validates the AdvSimd paths on the production ARM target, with and without hardware intrinsics.
- New `benchmark.yml` (`workflow_dispatch`): runner choice `ubuntu-latest` / `ubuntu-24.04-arm` / `both`, BenchmarkDotNet `--filter` input (default: the small `ByteSwapBench` suite), results into the job summary, and a `timeout-minutes` kill switch (default 10) so a hung run cannot burn runner time.
- New `ByteSwapBench`: platform-neutral A/B for these paths (`ToBigEndianAB`'s setup throws without AVX2, so it cannot run on ARM).

> Note: the last commit adds a temporary `push` trigger to `benchmark.yml` scoped to this branch — `workflow_dispatch` cannot target a workflow absent from the default branch. To be removed before merge (or squashed away).

## Testing

- New `BigEndian_Ctor_And_ToBigEndian_RoundTrip_Distinct_Bytes` test: 32 distinct byte values make any within-limb reversal or half-swap visible byte-by-byte; existing BigInteger-oracle tests cover all magnitudes.
- Full suite green locally (x64) and exercised on ARM by the new matrix rows: 575,822 tests passed.