### PR TITLE
Avoid SIMD materialization in UInt256 constructors and factories

### DIFF
--- a/src/Nethermind.Int256.Benchmark/UInt256UlongConstructorAB.cs
+++ b/src/Nethermind.Int256.Benchmark/UInt256UlongConstructorAB.cs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Nethermind.Int256.Benchmark;
+
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+public class UInt256UlongConstructorAB
+{
+    private const int N = 4096;
+
+    private readonly ulong[] _u0 = new ulong[N];
+    private readonly ulong[] _u1 = new ulong[N];
+    private readonly ulong[] _u2 = new ulong[N];
+    private readonly ulong[] _u3 = new ulong[N];
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        (ulong U0, ulong U1, ulong U2, ulong U3)[] values =
+        [
+            (0, 0, 0, 0),
+            (ulong.MaxValue, 0, 0, 0),
+            (0, ulong.MaxValue, 0, 0),
+            (0, 0, ulong.MaxValue, 0),
+            (0, 0, 0, ulong.MaxValue),
+            (0x0123_4567_89AB_CDEF, 0xFEDC_BA98_7654_3210, 0x8000_0000_0000_0000, 1),
+            (ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue),
+            (0x8000_0000_0000_0001, 0x7FFF_FFFF_FFFF_FFFE, 0xDEAD_BEEF_CAFE_BABE, 0x1357_9BDF_2468_ACE0),
+        ];
+
+        for (int i = 0; i < N; i++)
+        {
+            (ulong U0, ulong U1, ulong U2, ulong U3) value = values[i % values.Length];
+            _u0[i] = value.U0;
+            _u1[i] = value.U1;
+            _u2[i] = value.U2;
+            _u3[i] = value.U3;
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = N)]
+    public ulong Constructor()
+    {
+        ulong accumulator = 0;
+        for (int i = 0; i < N; i++)
+        {
+            UInt256 value = new(_u0[i], _u1[i], _u2[i], _u3[i]);
+            accumulator ^= value.u0 ^ value.u1 ^ value.u2 ^ value.u3;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public ulong LegacyVectorOrScalar()
+    {
+        ulong accumulator = 0;
+        for (int i = 0; i < N; i++)
+        {
+            UInt256 value = LegacyConstructor(_u0[i], _u1[i], _u2[i], _u3[i]);
+            accumulator ^= value.u0 ^ value.u1 ^ value.u2 ^ value.u3;
+        }
+
+        return accumulator;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static UInt256 LegacyConstructor(ulong u0, ulong u1, ulong u2, ulong u3)
+    {
+        UInt256 result;
+        if (Vector256.IsHardwareAccelerated)
+        {
+            Unsafe.SkipInit(out result);
+            Unsafe.As<UInt256, Vector256<ulong>>(ref result) = Vector256.Create(u0, u1, u2, u3);
+        }
+        else
+        {
+            Unsafe.SkipInit(out result);
+            ref ulong first = ref Unsafe.As<UInt256, ulong>(ref result);
+            first = u0;
+            Unsafe.Add(ref first, 1) = u1;
+            Unsafe.Add(ref first, 2) = u2;
+            Unsafe.Add(ref first, 3) = u3;
+        }
+
+        return result;
+    }
+}

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -653,6 +653,32 @@ public partial class UInt256Tests : UInt256TestsTemplate<UInt256>
 
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
 
+    public static TestCaseData[] UlongConstructorCases { get; } =
+    [
+        new TestCaseData(0UL, 0UL, 0UL, 0UL),
+        new TestCaseData(ulong.MaxValue, 0UL, 0UL, 0UL),
+        new TestCaseData(0UL, ulong.MaxValue, 0UL, 0UL),
+        new TestCaseData(0UL, 0UL, ulong.MaxValue, 0UL),
+        new TestCaseData(0UL, 0UL, 0UL, ulong.MaxValue),
+        new TestCaseData(0x8000_0000_0000_0000UL, 0x0123_4567_89AB_CDEFUL, 0xFEDC_BA98_7654_3210UL, 0x8000_0000_0000_0001UL),
+    ];
+
+    [TestCaseSource(nameof(UlongConstructorCases))]
+    public void UlongConstructor_WritesLimbs_AndRoundTrips(ulong u0, ulong u1, ulong u2, ulong u3)
+    {
+        UInt256 value = new(u0, u1, u2, u3);
+
+        value.u0.Should().Be(u0);
+        value.u1.Should().Be(u1);
+        value.u2.Should().Be(u2);
+        value.u3.Should().Be(u3);
+
+        BigInteger expected = (BigInteger)u0 + ((BigInteger)u1 << 64) + ((BigInteger)u2 << 128) + ((BigInteger)u3 << 192);
+        ((BigInteger)value).Should().Be(expected);
+        new UInt256(value.ToLittleEndian()).Should().Be(value);
+        new UInt256(value.ToBigEndian(), isBigEndian: true).Should().Be(value);
+    }
+
     public static IEnumerable<(UInt256 A, ulong A4, ulong D)> Remainder257By64BitsCases
     {
         get

--- a/src/Nethermind.Int256/UInt256.Ctors.cs
+++ b/src/Nethermind.Int256/UInt256.Ctors.cs
@@ -34,21 +34,10 @@ public readonly partial struct UInt256
 
     public UInt256(ulong u0 = 0, ulong u1 = 0, ulong u2 = 0, ulong u3 = 0)
     {
-        if (Vector256.IsHardwareAccelerated)
-        {
-            Unsafe.SkipInit(out this.u0);
-            Unsafe.SkipInit(out this.u1);
-            Unsafe.SkipInit(out this.u2);
-            Unsafe.SkipInit(out this.u3);
-            Unsafe.As<ulong, Vector256<ulong>>(ref this.u0) = Vector256.Create(u0, u1, u2, u3);
-        }
-        else
-        {
-            this.u0 = u0;
-            this.u1 = u1;
-            this.u2 = u2;
-            this.u3 = u3;
-        }
+        this.u0 = u0;
+        this.u1 = u1;
+        this.u2 = u2;
+        this.u3 = u3;
     }
 
     public UInt256(in ReadOnlySpan<byte> bytes, bool isBigEndian = false)

--- a/src/Nethermind.Int256/UInt256.Ctors.cs
+++ b/src/Nethermind.Int256/UInt256.Ctors.cs
@@ -219,21 +219,5 @@ public readonly partial struct UInt256
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static UInt256 Create(ulong u0, ulong u1, ulong u2, ulong u3)
-    {
-        if (Vector256.IsHardwareAccelerated)
-        {
-            Vector256<ulong> v = Vector256.Create(u0, u1, u2, u3);
-            return Unsafe.As<Vector256<ulong>, UInt256>(ref v);
-        }
-        else
-        {
-            Unsafe.SkipInit(out UInt256 r);
-            ref ulong p = ref Unsafe.As<UInt256, ulong>(ref r);
-            p = u0;
-            Unsafe.Add(ref p, 1) = u1;
-            Unsafe.Add(ref p, 2) = u2;
-            Unsafe.Add(ref p, 3) = u3;
-            return r;
-        }
-    }
+        => new(u0, u1, u2, u3);
 }


### PR DESCRIPTION
## Summary

- Write the four `UInt256` limbs directly in the public four-`ulong` constructor.
- Materialize the private `Create(ulong, ulong, ulong, ulong)` factory through that scalar constructor, removing its SIMD dispatch and temporary vector.
- Add focused limb-layout, BigInteger-oracle, and endian round-trip coverage.
- Public API and observable constructor/factory behavior remain unchanged.

## Hosted direct-Create evidence

The candidate and exact-#105 control used the same benchmark source (SHA-256 `135953EBBB56B5786BE62B804271AD4C1AE2B559BD1F0B958C8991555F0DCE48`). Values are ns per operation, with 3 launches, 3 warmups, and 10 iterations.

| Platform / mode | Candidate `Create` | Legacy `Create` | Exact-#105 `Create` | Candidate vs exact base |
| --- | ---: | ---: | ---: | ---: |
| AMD EPYC 7763 / HW | 3.720 ns | 4.494 ns | 4.429 ns | **-16.0%** |
| AMD EPYC 7763 / `DOTNET_EnableHWIntrinsic=0` | 3.851 ns | 3.888 ns | 3.790 ns | +1.6% |
| ARM Neoverse-N2 / HW | 3.697 ns | 3.717 ns | 3.736 ns | -1.0% |
| ARM Neoverse-N2 / `DOTNET_EnableHWIntrinsic=0` | 3.717 ns | 3.720 ns | 3.694 ns | +0.6% |

Within the candidate process, `Create` versus the equivalent legacy delegate was -17.2% on AMD HW and approximately neutral on AMD no-HW (-1.0%), ARM HW (-0.5%), and ARM no-HW (-0.1%). The matched legacy A/A control drift was at most 0.9%. Public Divide/Mod materialization stayed within about 1% on ARM in both modes; AMD public cross-run timing is not used for attribution because the two runs reported different host frequencies.

Candidate proof run: https://github.com/NethermindEth/int256/actions/runs/33171036551
Exact-#105 proof run: https://github.com/NethermindEth/int256/actions/runs/33171036785

Adjacent canonical RPC runs provide only cumulative context: alpha.8 to alpha.9 had nearly identical master arms, while alpha.9 (whose only int256 delta was the private factory simplification) measured CPU/AVG about 1.6% lower, replay median about 0.5% lower, and parity 497/497. This is not isolated attribution and is included only as supporting context.

## Validation

- Full local test suite, normal intrinsics: 575,832 passed (on the retained follow-up proof candidate; its temporary factory tests are not part of this PR).
- Full local test suite with `DOTNET_EnableHWIntrinsic=0`: 575,831 passed, 1 expected hardware-hash-path skip (on the retained follow-up proof candidate).
- Focused factory Divide/Mod BigInteger-oracle coverage: 4/4 passed in both modes (on the retained follow-up proof candidate; those temporary tests are intentionally excluded from this PR).
- Benchmark projects build successfully in Release.