### PR TITLE
Optimize MultiplyMod by the maximum modulus

### DIFF
--- a/src/Nethermind.Int256.Benchmark/MultiplyModMaxBenchmark.cs
+++ b/src/Nethermind.Int256.Benchmark/MultiplyModMaxBenchmark.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 
@@ -13,8 +14,8 @@ public enum MultiplyModMaxCase
     NarrowModulus,
 }
 
-// This benchmark is identical on the candidate and base branches. The branch A/B therefore
-// compares the max-modulus fold against the legacy full-width reduction with the same inputs.
+// This end-to-end benchmark is identical on the candidate and base branches, so branch A/B
+// compares the optimized public path with the legacy implementation on the same inputs.
 [SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
 [NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
 public class MultiplyModMaxTargeted
@@ -69,4 +70,103 @@ public class MultiplyModMaxTargeted
         seed ^ 0xE7037ED1A0B428DBUL | 1,
         seed ^ 0x8EBC6AF09C88C6E3UL | 1);
 
+}
+
+// Reduction-only A/B evidence. Both implementations consume the same precomputed product halves;
+// the private legacy reducer is bound once during setup, so delegate dispatch is part of this
+// algorithm-isolation measurement. The end-to-end benchmark above covers public-path integration.
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+public class MultiplyModMaxReductionTargeted
+{
+    private const int OperationCount = 1024;
+    private UInt256[] _lo = null!;
+    private UInt256[] _hi = null!;
+    private UInt256 _modulus;
+    private Reduction _fold = null!;
+    private Reduction _legacy = null!;
+
+    private delegate void Reduction(in UInt256 lo, in UInt256 hi, in UInt256 modulus, out UInt256 result);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _lo = new UInt256[OperationCount];
+        _hi = new UInt256[OperationCount];
+        _modulus = UInt256.MaxValue;
+
+        Product product = GetPrivateDelegate<Product>("Multiply256To512Bit");
+        _legacy = GetPrivateDelegate<Reduction>("Remainder512By256Bits");
+        _fold = FoldMaxModulus;
+
+        for (int i = 0; i < OperationCount; i++)
+        {
+            ulong seed = (ulong)i * 0x9E3779B97F4A7C15UL + 0xD1B54A32D192ED03UL;
+            UInt256 left = CreateFull(seed);
+            UInt256 right = CreateFull(seed ^ 0xA0761D6478BD642FUL);
+            product(in left, in right, out _lo[i], out _hi[i]);
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = OperationCount)]
+    public UInt256 LegacyReduction()
+    {
+        UInt256 aggregate = default;
+        UInt256[] lo = _lo;
+        UInt256[] hi = _hi;
+        UInt256 modulus = _modulus;
+        Reduction legacy = _legacy;
+        for (int i = 0; i < lo.Length; i++)
+        {
+            legacy(in lo[i], in hi[i], in modulus, out UInt256 result);
+            UInt256.Xor(in aggregate, in result, out aggregate);
+        }
+
+        return aggregate;
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationCount)]
+    public UInt256 MaxModulusFold()
+    {
+        UInt256 aggregate = default;
+        UInt256[] lo = _lo;
+        UInt256[] hi = _hi;
+        Reduction fold = _fold;
+        for (int i = 0; i < lo.Length; i++)
+        {
+            fold(in lo[i], in hi[i], in _modulus, out UInt256 result);
+            UInt256.Xor(in aggregate, in result, out aggregate);
+        }
+
+        return aggregate;
+    }
+
+    private static void FoldMaxModulus(in UInt256 lo, in UInt256 hi, in UInt256 modulus, out UInt256 result)
+    {
+        bool carry = UInt256.AddOverflow(in lo, in hi, out result);
+        if (carry)
+        {
+            UInt256.Add(in result, in UInt256.One, out result);
+        }
+
+        if (result.u3 == ulong.MaxValue && (result.u0 & result.u1 & result.u2) == ulong.MaxValue)
+        {
+            result = default;
+        }
+    }
+
+    private static TDelegate GetPrivateDelegate<TDelegate>(string name) where TDelegate : Delegate
+    {
+        MethodInfo method = typeof(UInt256).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new MissingMethodException(typeof(UInt256).FullName, name);
+        return method.CreateDelegate<TDelegate>();
+    }
+
+    private static UInt256 CreateFull(ulong seed) => new(
+        seed | 2,
+        seed ^ 0xA0761D6478BD642FUL | 1,
+        seed ^ 0xE7037ED1A0B428DBUL | 1,
+        seed ^ 0x8EBC6AF09C88C6E3UL | 1);
+
+    private delegate void Product(in UInt256 x, in UInt256 y, out UInt256 lo, out UInt256 hi);
 }

--- a/src/Nethermind.Int256.Benchmark/MultiplyModMaxBenchmark.cs
+++ b/src/Nethermind.Int256.Benchmark/MultiplyModMaxBenchmark.cs
@@ -15,8 +15,7 @@ public enum MultiplyModMaxCase
     NarrowModulus,
 }
 
-// This end-to-end benchmark is identical on the candidate and base branches, so branch A/B
-// compares the optimized public path with the legacy implementation on the same inputs.
+// End-to-end coverage exercises the public MultiplyMod path across representative moduli.
 [SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
 [NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
 public class MultiplyModMaxTargeted
@@ -70,12 +69,10 @@ public class MultiplyModMaxTargeted
         seed ^ 0xA0761D6478BD642FUL | 1,
         seed ^ 0xE7037ED1A0B428DBUL | 1,
         seed ^ 0x8EBC6AF09C88C6E3UL | 1);
-
 }
 
-// Reduction-only A/B evidence. Both implementations consume the same precomputed product halves;
-// the private legacy reducer is bound once during setup, so delegate dispatch is part of this
-// algorithm-isolation measurement. The end-to-end benchmark above covers public-path integration.
+// Reduction-only comparison isolates reduction from multiplication using precomputed product halves.
+// The private legacy reducer is bound once during setup, so delegate dispatch is part of the measurement.
 [SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
 [NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
 public class MultiplyModMaxReductionTargeted

--- a/src/Nethermind.Int256.Benchmark/MultiplyModMaxBenchmark.cs
+++ b/src/Nethermind.Int256.Benchmark/MultiplyModMaxBenchmark.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;

--- a/src/Nethermind.Int256.Benchmark/MultiplyModMaxBenchmark.cs
+++ b/src/Nethermind.Int256.Benchmark/MultiplyModMaxBenchmark.cs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Nethermind.Int256.Benchmark;
+
+public enum MultiplyModMaxCase
+{
+    MaxValue,
+    FullWidthMiss,
+    NarrowModulus,
+}
+
+// This benchmark is identical on the candidate and base branches. The branch A/B therefore
+// compares the max-modulus fold against the legacy full-width reduction with the same inputs.
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+public class MultiplyModMaxTargeted
+{
+    private const int OperationCount = 1024;
+    private UInt256[] _left = null!;
+    private UInt256[] _right = null!;
+    private UInt256[] _modulus = null!;
+
+    [Params(MultiplyModMaxCase.MaxValue, MultiplyModMaxCase.FullWidthMiss, MultiplyModMaxCase.NarrowModulus)]
+    public MultiplyModMaxCase Case { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _left = new UInt256[OperationCount];
+        _right = new UInt256[OperationCount];
+        _modulus = new UInt256[OperationCount];
+        for (int i = 0; i < _left.Length; i++)
+        {
+            ulong seed = (ulong)i * 0x9E3779B97F4A7C15UL + 0xD1B54A32D192ED03UL;
+            _left[i] = CreateFull(seed);
+            _right[i] = CreateFull(seed ^ 0xA0761D6478BD642FUL);
+            _modulus[i] = Case switch
+            {
+                MultiplyModMaxCase.MaxValue => UInt256.MaxValue,
+                MultiplyModMaxCase.FullWidthMiss => new UInt256(ulong.MaxValue - 1, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue),
+                _ => new UInt256(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, 0),
+            };
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationCount)]
+    public UInt256 MultiplyMod()
+    {
+        UInt256 aggregate = default;
+        UInt256[] left = _left;
+        UInt256[] right = _right;
+        UInt256[] modulus = _modulus;
+        for (int i = 0; i < left.Length; i++)
+        {
+            UInt256.MultiplyMod(in left[i], in right[i], in modulus[i], out UInt256 result);
+            UInt256.Xor(in aggregate, in result, out aggregate);
+        }
+
+        return aggregate;
+    }
+
+    private static UInt256 CreateFull(ulong seed) => new(
+        seed | 2,
+        seed ^ 0xA0761D6478BD642FUL | 1,
+        seed ^ 0xE7037ED1A0B428DBUL | 1,
+        seed ^ 0x8EBC6AF09C88C6E3UL | 1);
+
+}

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -653,6 +653,58 @@ public partial class UInt256Tests : UInt256TestsTemplate<UInt256>
 
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
 
+    [Test]
+    public void MultiplyMod_by_max_value_matches_BigInteger()
+    {
+        Random random = new(0);
+        byte[] operands = new byte[64];
+        UInt256[] boundaryValues =
+        [
+            default,
+            UInt256.One,
+            new UInt256(2),
+            new UInt256(ulong.MaxValue),
+            new UInt256(0, 1),
+            new UInt256(0, 0, 1),
+            UInt256.MaxValue - 1,
+            UInt256.MaxValue,
+        ];
+
+        foreach (UInt256 x in boundaryValues)
+        {
+            foreach (UInt256 y in boundaryValues)
+            {
+                AssertResult(in x, in y);
+            }
+        }
+
+        for (int i = 0; i < 4096; i++)
+        {
+            random.NextBytes(operands);
+            AssertResult(new UInt256(operands.AsSpan(0, 32)), new UInt256(operands.AsSpan(32, 32)));
+        }
+
+        static void AssertResult(in UInt256 x, in UInt256 y)
+        {
+            BigInteger expected = (BigInteger)x * (BigInteger)y % TestNumbers.UInt256Max;
+
+            UInt256.MultiplyMod(in x, in y, in UInt256.MaxValue, out UInt256 result);
+            ((BigInteger)result).Should().Be(expected);
+
+            UInt256 left = x;
+            UInt256 modulus = UInt256.MaxValue;
+            left.MultiplyMod(in y, in modulus, out left);
+            ((BigInteger)left).Should().Be(expected);
+
+            UInt256 right = y;
+            x.MultiplyMod(in right, in modulus, out right);
+            ((BigInteger)right).Should().Be(expected);
+
+            x.MultiplyMod(in y, in modulus, out modulus);
+            ((BigInteger)modulus).Should().Be(expected);
+        }
+    }
+
     public static IEnumerable<(UInt256 A, ulong A4, ulong D)> Remainder257By64BitsCases
     {
         get

--- a/src/Nethermind.Int256/UInt256.DivideMod.cs
+++ b/src/Nethermind.Int256/UInt256.DivideMod.cs
@@ -351,6 +351,23 @@ public readonly partial struct UInt256
             return;
         }
 
+        if (m.u3 == ulong.MaxValue && (m.u0 & m.u1 & m.u2) == ulong.MaxValue)
+        {
+            // 2^256 is congruent to 1 modulo 2^256 - 1, so fold the high half into the low half.
+            bool carry = AddOverflow(in lo, in hi, out res);
+            if (carry)
+            {
+                Add(in res, in One, out res);
+            }
+
+            if (res.u3 == ulong.MaxValue && (res.u0 & res.u1 & res.u2) == ulong.MaxValue)
+            {
+                res = default;
+            }
+
+            return;
+        }
+
         if (m.u3 != 0)
         {
             Remainder512By256Bits(in lo, in hi, in m, out res);


### PR DESCRIPTION
﻿## Summary

Optimize `UInt256.MultiplyMod` when the modulus is exactly `2^256 - 1`. The high product half is folded into the low half with end-around carry, followed by the canonical zero normalization. The existing `hi.IsZero` fast path remains first and the public API is unchanged.

## Correctness

- Deterministic boundary values and 4096 deterministic random operand pairs checked against `BigInteger`.
- Static, receiver, x-output, y-output, and modulus-output aliasing are covered.
- Focused test passes in default and `DOTNET_EnableHWIntrinsic=0` modes.

## Benchmark evidence

The target modulus occurs in 54.61% of instrumented calls: 2,102,273 / 3,849,776 `MultiplyMod` calls.

Reduction-only same-process evidence (precomputed product halves, legacy reducer as baseline):

| Runner | Mode | Legacy | Fold | Change |
| --- | --- | ---: | ---: | ---: |
| AMD | HW | 78.324 ns | 5.058 ns | -93.5% |
| AMD | NoIntrinsics | 147.099 ns | 8.806 ns | -94.0% |
| ARM | HW | 70.366 ns | 7.960 ns | -88.7% |
| ARM | NoIntrinsics | 107.334 ns | 7.919 ns | -92.6% |

ARM exact-base public MaxValue comparison:

- HW: 98.34 ns -> 33.95 ns (-65.5%)
- NoIntrinsics: 169.90 ns -> 66.65 ns (-60.8%)
- FullWidthMiss and NarrowModulus controls stayed within 0.5%.

The hosted AMD candidate/base public runs used different EPYC models. Therefore the raw AMD absolute values are not treated as same-host A/B. Same-run normalized MaxValue-vs-miss improvement was approximately -66.9% HW and -58.3% NoIntrinsics, supported by the reduction-isolation results above.

Hosted benchmark runs: [candidate 33168549255](https://github.com/NethermindEth/int256/actions/runs/33168549255), [base 33168552265](https://github.com/NethermindEth/int256/actions/runs/33168552265).

The isolated canonical AMD RPC run [33140718492](https://github.com/NethermindEth/nethermind/actions/runs/33140718492) was neutral with no measurable regression: CPU/request +0.6%, average +0.4%, replay median -0.2%, parity 497/497.

## Validation

- Focused correctness test: default and no-HW, 1/1 passed in each mode.
- `git diff --check` passes.


Caveat: The isolated RPC run also emitted the same single case-insensitive ERROR pattern warning in both exact master and candidate; it was shared/non-candidate-specific (corpus privacy hid the content). The workflow otherwise succeeded, the snapshot remained pristine, and the normal-shutdown gate passed; the logs should not be described as clean.
