### PR TITLE
Optimize UInt256.CompareTo with direct limb comparison

### DIFF
--- a/src/Nethermind.Int256.Benchmark/UInt256CompareToBenchmark.cs
+++ b/src/Nethermind.Int256.Benchmark/UInt256CompareToBenchmark.cs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Nethermind.Int256;
+
+namespace Nethermind.Int256.Benchmark;
+
+public enum UInt256CompareToCase
+{
+    Equal,
+    DifferentLimb3,
+    DifferentLimb2,
+    DifferentLimb1,
+    DifferentLimb0,
+    Random,
+}
+
+/// <summary>
+/// Compares UInt256.CompareTo with the pre-optimization comparison dispatch for equal values and
+/// every possible first differing limb. No corpus weighting is included because no CompareTo incidence
+/// capture is available.
+/// </summary>
+[HideColumns("Job", "RatioSD", "Error")]
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+public class UInt256CompareToBenchmark
+{
+    private const int BatchSize = 1024;
+
+    private readonly UInt256[] _left = new UInt256[BatchSize];
+    private readonly UInt256[] _right = new UInt256[BatchSize];
+
+    [Params(
+        UInt256CompareToCase.Equal,
+        UInt256CompareToCase.DifferentLimb3,
+        UInt256CompareToCase.DifferentLimb2,
+        UInt256CompareToCase.DifferentLimb1,
+        UInt256CompareToCase.DifferentLimb0,
+        UInt256CompareToCase.Random)]
+    public UInt256CompareToCase Case { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Random random = new(0xC0_4D_50);
+        for (int i = 0; i < BatchSize; i++)
+        {
+            UInt256 left = RandomValue(random);
+            _left[i] = left;
+            _right[i] = CreateRight(random, left, i);
+
+            int expected = Math.Sign(((BigInteger)left).CompareTo((BigInteger)_right[i]));
+            int current = left.CompareTo(_right[i]);
+            int legacy = LegacyCompareTo(in left, in _right[i]);
+            if (current != expected || legacy != expected)
+            {
+                throw new InvalidOperationException($"Comparison mismatch at index {i} for {Case}.");
+            }
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = BatchSize)]
+    public int CompareTo_Legacy()
+    {
+        int checksum = 0;
+        for (int i = 0; i < BatchSize; i++)
+        {
+            checksum = unchecked(checksum * 31 + LegacyCompareTo(in _left[i], in _right[i]));
+        }
+
+        return checksum;
+    }
+
+    [Benchmark(OperationsPerInvoke = BatchSize)]
+    public int CompareTo_Current()
+    {
+        int checksum = 0;
+        for (int i = 0; i < BatchSize; i++)
+        {
+            checksum = unchecked(checksum * 31 + _left[i].CompareTo(_right[i]));
+        }
+
+        return checksum;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int LegacyCompareTo(in UInt256 a, in UInt256 b)
+        => a < b ? -1 : a.Equals(b) ? 0 : 1;
+
+    private UInt256 CreateRight(Random random, UInt256 left, int index)
+    {
+        switch (Case)
+        {
+            case UInt256CompareToCase.Equal:
+                return left;
+            case UInt256CompareToCase.DifferentLimb3:
+                return new UInt256(left.u0, left.u1, left.u2, left.u3 ^ (1UL << (index & 63)));
+            case UInt256CompareToCase.DifferentLimb2:
+                return new UInt256(left.u0, left.u1, left.u2 ^ (1UL << (index & 63)), left.u3);
+            case UInt256CompareToCase.DifferentLimb1:
+                return new UInt256(left.u0, left.u1 ^ (1UL << (index & 63)), left.u2, left.u3);
+            case UInt256CompareToCase.DifferentLimb0:
+                return new UInt256(left.u0 ^ (1UL << (index & 63)), left.u1, left.u2, left.u3);
+            case UInt256CompareToCase.Random:
+                return RandomValue(random);
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private static UInt256 RandomValue(Random random)
+        => new(NextUInt64(random), NextUInt64(random), NextUInt64(random), NextUInt64(random));
+
+    private static ulong NextUInt64(Random random)
+        => (ulong)random.NextInt64() ^ ((ulong)random.NextInt64() << 32);
+}

--- a/src/Nethermind.Int256.Tests/UInt256CompareTests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256CompareTests.cs
@@ -9,6 +9,21 @@ namespace Nethermind.Int256.Test;
 public partial class UInt256Tests
 {
     [Test]
+    public void CompareTo_Uses_the_first_differing_limb()
+    {
+        UInt256 common = new(0x0123_4567_89AB_CDEFUL, 0x1111_2222_3333_4444UL, 0x5555_6666_7777_8888UL, 0x9999_AAAA_BBBB_CCCCUL);
+
+        AssertCompare(new UInt256(common.u0, common.u1, common.u2, common.u3 - 1), common, -1);
+        AssertCompare(common, new UInt256(common.u0, common.u1, common.u2, common.u3 - 1), 1);
+        AssertCompare(new UInt256(common.u0, common.u1, common.u2 - 1, common.u3), common, -1);
+        AssertCompare(common, new UInt256(common.u0, common.u1, common.u2 - 1, common.u3), 1);
+        AssertCompare(new UInt256(common.u0, common.u1 - 1, common.u2, common.u3), common, -1);
+        AssertCompare(common, new UInt256(common.u0, common.u1 - 1, common.u2, common.u3), 1);
+        AssertCompare(new UInt256(common.u0 - 1, common.u1, common.u2, common.u3), common, -1);
+        AssertCompare(common, new UInt256(common.u0 - 1, common.u1, common.u2, common.u3), 1);
+    }
+
+    [Test]
     public void CompareTo_Matches_BigInteger()
     {
         UInt256[] values =
@@ -43,5 +58,12 @@ public partial class UInt256Tests
                 Assert.That(Math.Sign(a.CompareTo((object)b)), Is.EqualTo(expected));
             }
         }
+    }
+
+    private static void AssertCompare(UInt256 a, UInt256 b, int expected)
+    {
+        Assert.That(a.CompareTo(in b), Is.EqualTo(expected));
+        Assert.That(a.CompareTo(b), Is.EqualTo(expected));
+        Assert.That(a.CompareTo((object)b), Is.EqualTo(expected));
     }
 }

--- a/src/Nethermind.Int256.Tests/UInt256CompareTests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256CompareTests.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Numerics;
+using NUnit.Framework;
+
+namespace Nethermind.Int256.Test;
+
+public partial class UInt256Tests
+{
+    [Test]
+    public void CompareTo_Matches_BigInteger()
+    {
+        UInt256[] values =
+        [
+            UInt256.Zero,
+            UInt256.One,
+            new UInt256(ulong.MaxValue),
+            new UInt256(0, ulong.MaxValue, 0, 0),
+            new UInt256(0, 0, ulong.MaxValue, 0),
+            new UInt256(0, 0, 0, ulong.MaxValue),
+            new UInt256(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue),
+        ];
+
+        Random random = new(42);
+        Array.Resize(ref values, values.Length + 128);
+        for (int i = 7; i < values.Length; i++)
+        {
+            values[i] = new UInt256(
+                (ulong)random.NextInt64(),
+                (ulong)random.NextInt64(),
+                (ulong)random.NextInt64(),
+                (ulong)random.NextInt64());
+        }
+
+        foreach (UInt256 a in values)
+        {
+            foreach (UInt256 b in values)
+            {
+                int expected = Math.Sign(((BigInteger)a).CompareTo((BigInteger)b));
+                Assert.That(Math.Sign(a.CompareTo(in b)), Is.EqualTo(expected));
+                Assert.That(Math.Sign(a.CompareTo(b)), Is.EqualTo(expected));
+                Assert.That(Math.Sign(a.CompareTo((object)b)), Is.EqualTo(expected));
+            }
+        }
+    }
+}

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -1266,8 +1266,15 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
 
     public int CompareTo(UInt256 b) => CompareTo(in b);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [OverloadResolutionPriority(1)]
-    public int CompareTo(in UInt256 b) => this < b ? -1 : Equals(b) ? 0 : 1;
+    public int CompareTo(in UInt256 b)
+    {
+        if (u3 != b.u3) return u3 < b.u3 ? -1 : 1;
+        if (u2 != b.u2) return u2 < b.u2 ? -1 : 1;
+        if (u1 != b.u1) return u1 < b.u1 ? -1 : 1;
+        return u0 == b.u0 ? 0 : u0 < b.u0 ? -1 : 1;
+    }
 
     public override bool Equals(object? obj) => obj is UInt256 other && Equals(other);
 


### PR DESCRIPTION
## Summary

Replace `UInt256.CompareTo(in UInt256)`'s indirect `<`/`Equals` dispatch with a direct high-to-low limb comparison. The implementation preserves exact `-1`, `0`, and `1` results and the existing `IComparable<UInt256>`/`IComparable` API; no public surface changes.

The only library caller is the `DivideMod` comparison gate, which requires only `-1`, `0`, or a positive result. Instrumentation recorded 213,862,977 `CompareTo` calls, but did not capture the equal/first-differing-limb distribution. No invented corpus weighting is used.

## Hosted microbenchmarks

The same-process A/B benchmark compares the candidate against the exact pre-change expression (`a < b ? -1 : a.Equals(b) ? 0 : 1`) for equal values, first differences at limbs 3/2/1/0, and deterministic random values. Every result is consumed, and setup checks both implementations against a `BigInteger` oracle.

| runner | mode | Equal | Limb 3 | Limb 2 | Limb 1 | Limb 0 | Random |
|---|---:|---:|---:|---:|---:|---:|---:|
| AMD EPYC | HW intrinsics | +0.9% | -35.6% | -27.9% | -19.5% | -10.6% | -35.1% |
| AMD EPYC | no intrinsics | -40.9% | -24.2% | -28.5% | -27.6% | -22.3% | -27.5% |
| ARM Neoverse-N2 | HW intrinsics | -32.1% | -26.2% | -24.8% | -23.1% | -19.3% | -26.6% |
| ARM Neoverse-N2 | no intrinsics | -32.3% | -27.5% | -24.3% | -21.4% | -20.6% | -26.6% |

Negative is faster. The AMD HW equal case is neutral (+0.9%); every other measured candidate shape is faster by 10.6%–40.9%. The matched base branch uses byte-for-byte identical benchmark code and keeps its Current-vs-Legacy A/A control within approximately ±1.4% (one ARM case -3.2%). Candidate and base AMD jobs used different EPYC models, so raw cross-run timings are not compared.

Runs: [candidate, AMD64 + ARM64 HW/noHW](https://github.com/NethermindEth/int256/actions/runs/33169625708) / [matched exact-base A/A](https://github.com/NethermindEth/int256/actions/runs/33169629174).

## Correctness

- Focused tests cover equal values and both directions with the first differing limb at 3, 2, 1, and 0.
- 128 deterministic randomized values are cross-checked pairwise against `BigInteger`.
- The by-reference, by-value, and boxed `CompareTo` overloads are checked.
- Default focused test run: 2 passed, 0 failed.
- `DOTNET_EnableHWIntrinsic=0` and `DOTNET_EnableAVX2=0`: 2 passed, 0 failed.

This PR contains microbenchmark evidence only; no isolated RPC attribution is claimed.