### PR TITLE
Optimize UInt256.AddOverflow for narrow operands

### DIFF
--- a/src/Nethermind.Int256.Benchmark/AddOverflowDispatchBenchmark.cs
+++ b/src/Nethermind.Int256.Benchmark/AddOverflowDispatchBenchmark.cs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Nethermind.Int256.Benchmark;
+
+public enum AddOverflowCase
+{
+    Distribution,
+    Small64,
+    Full,
+}
+
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+public class AddOverflowDispatchAB
+{
+    private const int N = 4096;
+    private const int DistributionSmallCount = 3604; // 3604/4096 approximates measured 173,674,474/197,390,360 = 87.985%.
+
+    private UInt256[] _a = null!;
+    private UInt256[] _b = null!;
+    private AddOverflowDelegate _addVector256 = null!;
+
+    [Params(AddOverflowCase.Distribution, AddOverflowCase.Small64, AddOverflowCase.Full)]
+    public AddOverflowCase Case;
+
+    private delegate bool AddOverflowDelegate(in UInt256 a, in UInt256 b, out UInt256 result);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!Avx2.IsSupported && Vector256.IsHardwareAccelerated)
+        {
+            _addVector256 = (AddOverflowDelegate)typeof(UInt256)
+                .GetMethod("AddVector256", BindingFlags.NonPublic | BindingFlags.Static)!
+                .CreateDelegate(typeof(AddOverflowDelegate));
+        }
+
+        _a = new UInt256[N];
+        _b = new UInt256[N];
+        Random random = new(0xADD0_497);
+
+        for (int i = 0; i < N; i++)
+        {
+            (UInt256 a, UInt256 b) = Case switch
+            {
+                AddOverflowCase.Distribution => DistributionPair(i, random),
+                AddOverflowCase.Small64 => Small64Pair(random),
+                AddOverflowCase.Full => FullPair(random),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+            _a[i] = a;
+            _b[i] = b;
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = N)]
+    public ulong Add_CurrentDispatch()
+    {
+        UInt256[] a = _a, b = _b;
+        ulong accumulator = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            bool overflow = AddCurrentDispatch(in a[i], in b[i], out UInt256 result);
+            accumulator ^= result.u0 ^ result.u1 ^ result.u2 ^ result.u3;
+            accumulator ^= overflow ? 1UL : 0UL;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public ulong Add_GatedDispatch()
+    {
+        UInt256[] a = _a, b = _b;
+        ulong accumulator = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            bool overflow = UInt256.AddOverflow(in a[i], in b[i], out UInt256 result);
+            accumulator ^= result.u0 ^ result.u1 ^ result.u2 ^ result.u3;
+            accumulator ^= overflow ? 1UL : 0UL;
+        }
+
+        return accumulator;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool AddCurrentDispatch(in UInt256 a, in UInt256 b, out UInt256 result)
+    {
+        if (!Avx2.IsSupported && !Vector256.IsHardwareAccelerated)
+        {
+            return UInt256.AddScalar(in a, in b, out result);
+        }
+
+        if (Avx2.IsSupported)
+        {
+            return UInt256.AddAvx2(in a, in b, out result);
+        }
+
+        return _addVector256(in a, in b, out result);
+    }
+
+    private static (UInt256 A, UInt256 B) DistributionPair(int index, Random random)
+        => index < DistributionSmallCount
+            ? Small64Pair(random)
+            : FullPair(random);
+
+    private static (UInt256 A, UInt256 B) Small64Pair(Random random)
+        => (new UInt256((ulong)random.NextInt64()), new UInt256((ulong)random.NextInt64()));
+
+    private static (UInt256 A, UInt256 B) FullPair(Random random)
+        => (new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64() | 1),
+            new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64() | 1));
+}

--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -8,7 +8,6 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -283,116 +282,6 @@ public class ArithmeticPathAB
         return acc;
     }
 
-}
-
-public enum AddOverflowCase
-{
-    Distribution,
-    Small64,
-    Full,
-}
-
-[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
-[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
-public class AddOverflowDispatchAB
-{
-    private const int N = 4096;
-    private const int DistributionSmallCount = 3604; // 3604/4096 approximates measured 173,674,474/197,390,360 = 87.985%.
-
-    private UInt256[] _a = null!;
-    private UInt256[] _b = null!;
-    private AddOverflowDelegate _addVector256 = null!;
-
-    [Params(AddOverflowCase.Distribution, AddOverflowCase.Small64, AddOverflowCase.Full)]
-    public AddOverflowCase Case;
-
-    private delegate bool AddOverflowDelegate(in UInt256 a, in UInt256 b, out UInt256 result);
-
-    [GlobalSetup]
-    public void Setup()
-    {
-        if (!Avx2.IsSupported && Vector256.IsHardwareAccelerated)
-        {
-            _addVector256 = (AddOverflowDelegate)typeof(UInt256)
-                .GetMethod("AddVector256", BindingFlags.NonPublic | BindingFlags.Static)!
-                .CreateDelegate(typeof(AddOverflowDelegate));
-        }
-
-        _a = new UInt256[N];
-        _b = new UInt256[N];
-        Random random = new(0xADD0_497);
-
-        for (int i = 0; i < N; i++)
-        {
-            (UInt256 a, UInt256 b) = Case switch
-            {
-                AddOverflowCase.Distribution => DistributionPair(i, random),
-                AddOverflowCase.Small64 => Small64Pair(random),
-                AddOverflowCase.Full => FullPair(random),
-                _ => throw new ArgumentOutOfRangeException(),
-            };
-            _a[i] = a;
-            _b[i] = b;
-        }
-    }
-
-    [Benchmark(Baseline = true, OperationsPerInvoke = N)]
-    public ulong Add_CurrentDispatch()
-    {
-        UInt256[] a = _a, b = _b;
-        ulong accumulator = 0;
-        for (int i = 0; i < a.Length; i++)
-        {
-            bool overflow = AddCurrentDispatch(in a[i], in b[i], out UInt256 result);
-            accumulator ^= result.u0 ^ result.u1 ^ result.u2 ^ result.u3;
-            accumulator ^= overflow ? 1UL : 0UL;
-        }
-
-        return accumulator;
-    }
-
-    [Benchmark(OperationsPerInvoke = N)]
-    public ulong Add_GatedDispatch()
-    {
-        UInt256[] a = _a, b = _b;
-        ulong accumulator = 0;
-        for (int i = 0; i < a.Length; i++)
-        {
-            bool overflow = UInt256.AddOverflow(in a[i], in b[i], out UInt256 result);
-            accumulator ^= result.u0 ^ result.u1 ^ result.u2 ^ result.u3;
-            accumulator ^= overflow ? 1UL : 0UL;
-        }
-
-        return accumulator;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool AddCurrentDispatch(in UInt256 a, in UInt256 b, out UInt256 result)
-    {
-        if (!Avx2.IsSupported && !Vector256.IsHardwareAccelerated)
-        {
-            return UInt256.AddScalar(in a, in b, out result);
-        }
-
-        if (Avx2.IsSupported)
-        {
-            return UInt256.AddAvx2(in a, in b, out result);
-        }
-
-        return _addVector256(in a, in b, out result);
-    }
-
-    private static (UInt256 A, UInt256 B) DistributionPair(int index, Random random)
-        => index < DistributionSmallCount
-            ? Small64Pair(random)
-            : FullPair(random);
-
-    private static (UInt256 A, UInt256 B) Small64Pair(Random random)
-        => (new UInt256((ulong)random.NextInt64()), new UInt256((ulong)random.NextInt64()));
-
-    private static (UInt256 A, UInt256 B) FullPair(Random random)
-        => (new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64() | 1),
-            new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64() | 1));
 }
 
 // LessThan A/B across operand relationships: DifferHigh (scalar exits after one compare),

--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -284,6 +284,125 @@ public class ArithmeticPathAB
 
 }
 
+public enum AddOverflowCase
+{
+    Distribution,
+    Small64,
+    Small64Carry,
+    Mid128,
+    Full,
+    Mixed,
+}
+
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
+public class AddOverflowDispatchAB
+{
+    private const int N = 4096;
+    private const int DistributionSmallCount = 3604;
+
+    private UInt256[] _a = null!;
+    private UInt256[] _b = null!;
+
+    [Params(AddOverflowCase.Distribution, AddOverflowCase.Small64, AddOverflowCase.Small64Carry,
+        AddOverflowCase.Mid128, AddOverflowCase.Full, AddOverflowCase.Mixed)]
+    public AddOverflowCase Case;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _a = new UInt256[N];
+        _b = new UInt256[N];
+        Random random = new(0xADD0_497);
+
+        for (int i = 0; i < N; i++)
+        {
+            (UInt256 a, UInt256 b) = Case switch
+            {
+                AddOverflowCase.Distribution => DistributionPair(i, random),
+                AddOverflowCase.Small64 => Small64Pair(random),
+                AddOverflowCase.Small64Carry => (new UInt256(ulong.MaxValue), new UInt256((ulong)i + 1)),
+                AddOverflowCase.Mid128 => Mid128Pair(random),
+                AddOverflowCase.Full => FullPair(random),
+                _ => MixedPair(i, random),
+            };
+            _a[i] = a;
+            _b[i] = b;
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = N)]
+    public ulong Add_CurrentDispatch()
+    {
+        UInt256[] a = _a, b = _b;
+        ulong accumulator = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            bool overflow = AddCurrentDispatch(in a[i], in b[i], out UInt256 result);
+            accumulator ^= result.u0 ^ result.u1 ^ result.u2 ^ result.u3;
+            accumulator ^= overflow ? 1UL : 0UL;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public ulong Add_GatedDispatch()
+    {
+        UInt256[] a = _a, b = _b;
+        ulong accumulator = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            bool overflow = UInt256.AddOverflow(in a[i], in b[i], out UInt256 result);
+            accumulator ^= result.u0 ^ result.u1 ^ result.u2 ^ result.u3;
+            accumulator ^= overflow ? 1UL : 0UL;
+        }
+
+        return accumulator;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AddCurrentDispatch(in UInt256 a, in UInt256 b, out UInt256 result)
+    {
+        if (!Avx2.IsSupported && !Vector256.IsHardwareAccelerated)
+        {
+            return UInt256.AddScalar(in a, in b, out result);
+        }
+
+        if (Avx2.IsSupported)
+        {
+            return UInt256.AddAvx2(in a, in b, out result);
+        }
+
+        throw new PlatformNotSupportedException($"{nameof(AddOverflowDispatchAB)} requires AVX2 on the default hardware job.");
+    }
+
+    private static (UInt256 A, UInt256 B) DistributionPair(int index, Random random)
+        => index < DistributionSmallCount
+            ? Small64Pair(random)
+            : (index % 3) switch
+            {
+                0 => Mid128Pair(random),
+                1 => FullPair(random),
+                _ => (new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64()),
+                    new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), 1)),
+            };
+
+    private static (UInt256 A, UInt256 B) MixedPair(int index, Random random)
+        => (index & 1) == 0 ? Small64Pair(random) : Mid128Pair(random);
+
+    private static (UInt256 A, UInt256 B) Small64Pair(Random random)
+        => (new UInt256((ulong)random.NextInt64()), new UInt256((ulong)random.NextInt64()));
+
+    private static (UInt256 A, UInt256 B) Mid128Pair(Random random)
+        => (new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64() | 1),
+            new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64() | 1));
+
+    private static (UInt256 A, UInt256 B) FullPair(Random random)
+        => (new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64() | 1),
+            new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64() | 1));
+}
+
 // LessThan A/B across operand relationships: DifferHigh (scalar exits after one compare),
 // DifferLow and Equal (scalar walks all four limbs).
 public enum LtCase

--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -297,7 +297,7 @@ public enum AddOverflowCase
 public class AddOverflowDispatchAB
 {
     private const int N = 4096;
-    private const int DistributionSmallCount = 3604;
+    private const int DistributionSmallCount = 3604; // 3604/4096 approximates measured 173,674,474/197,390,360 = 87.985%.
 
     private UInt256[] _a = null!;
     private UInt256[] _b = null!;
@@ -329,6 +329,7 @@ public class AddOverflowDispatchAB
                 AddOverflowCase.Distribution => DistributionPair(i, random),
                 AddOverflowCase.Small64 => Small64Pair(random),
                 AddOverflowCase.Full => FullPair(random),
+                _ => throw new ArgumentOutOfRangeException(),
             };
             _a[i] = a;
             _b[i] = b;

--- a/src/Nethermind.Int256.Benchmark/Benchmarks.cs
+++ b/src/Nethermind.Int256.Benchmark/Benchmarks.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -288,14 +289,11 @@ public enum AddOverflowCase
 {
     Distribution,
     Small64,
-    Small64Carry,
-    Mid128,
     Full,
-    Mixed,
 }
 
-[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
-[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 6, warmupCount: 3, iterationCount: 10)]
+[SimpleJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
+[NoIntrinsicsJob(RuntimeMoniker.Net10_0, launchCount: 3, warmupCount: 3, iterationCount: 10)]
 public class AddOverflowDispatchAB
 {
     private const int N = 4096;
@@ -303,14 +301,23 @@ public class AddOverflowDispatchAB
 
     private UInt256[] _a = null!;
     private UInt256[] _b = null!;
+    private AddOverflowDelegate _addVector256 = null!;
 
-    [Params(AddOverflowCase.Distribution, AddOverflowCase.Small64, AddOverflowCase.Small64Carry,
-        AddOverflowCase.Mid128, AddOverflowCase.Full, AddOverflowCase.Mixed)]
+    [Params(AddOverflowCase.Distribution, AddOverflowCase.Small64, AddOverflowCase.Full)]
     public AddOverflowCase Case;
+
+    private delegate bool AddOverflowDelegate(in UInt256 a, in UInt256 b, out UInt256 result);
 
     [GlobalSetup]
     public void Setup()
     {
+        if (!Avx2.IsSupported && Vector256.IsHardwareAccelerated)
+        {
+            _addVector256 = (AddOverflowDelegate)typeof(UInt256)
+                .GetMethod("AddVector256", BindingFlags.NonPublic | BindingFlags.Static)!
+                .CreateDelegate(typeof(AddOverflowDelegate));
+        }
+
         _a = new UInt256[N];
         _b = new UInt256[N];
         Random random = new(0xADD0_497);
@@ -321,10 +328,7 @@ public class AddOverflowDispatchAB
             {
                 AddOverflowCase.Distribution => DistributionPair(i, random),
                 AddOverflowCase.Small64 => Small64Pair(random),
-                AddOverflowCase.Small64Carry => (new UInt256(ulong.MaxValue), new UInt256((ulong)i + 1)),
-                AddOverflowCase.Mid128 => Mid128Pair(random),
                 AddOverflowCase.Full => FullPair(random),
-                _ => MixedPair(i, random),
             };
             _a[i] = a;
             _b[i] = b;
@@ -362,7 +366,7 @@ public class AddOverflowDispatchAB
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool AddCurrentDispatch(in UInt256 a, in UInt256 b, out UInt256 result)
+    private bool AddCurrentDispatch(in UInt256 a, in UInt256 b, out UInt256 result)
     {
         if (!Avx2.IsSupported && !Vector256.IsHardwareAccelerated)
         {
@@ -374,29 +378,16 @@ public class AddOverflowDispatchAB
             return UInt256.AddAvx2(in a, in b, out result);
         }
 
-        throw new PlatformNotSupportedException($"{nameof(AddOverflowDispatchAB)} requires AVX2 on the default hardware job.");
+        return _addVector256(in a, in b, out result);
     }
 
     private static (UInt256 A, UInt256 B) DistributionPair(int index, Random random)
         => index < DistributionSmallCount
             ? Small64Pair(random)
-            : (index % 3) switch
-            {
-                0 => Mid128Pair(random),
-                1 => FullPair(random),
-                _ => (new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64()),
-                    new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), 1)),
-            };
-
-    private static (UInt256 A, UInt256 B) MixedPair(int index, Random random)
-        => (index & 1) == 0 ? Small64Pair(random) : Mid128Pair(random);
+            : FullPair(random);
 
     private static (UInt256 A, UInt256 B) Small64Pair(Random random)
         => (new UInt256((ulong)random.NextInt64()), new UInt256((ulong)random.NextInt64()));
-
-    private static (UInt256 A, UInt256 B) Mid128Pair(Random random)
-        => (new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64() | 1),
-            new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64() | 1));
 
     private static (UInt256 A, UInt256 B) FullPair(Random random)
         => (new UInt256((ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64(), (ulong)random.NextInt64() | 1),

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -653,6 +653,50 @@ public partial class UInt256Tests : UInt256TestsTemplate<UInt256>
 
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
 
+    [TestCase(0UL, 0UL)]
+    [TestCase(1UL, 2UL)]
+    [TestCase(ulong.MaxValue, 1UL)]
+    [TestCase(ulong.MaxValue, ulong.MaxValue)]
+    public void AddOverflow_narrow_values_preserve_result_overflow_and_aliases(ulong aValue, ulong bValue)
+    {
+        AssertAddOverflow(new UInt256(aValue), new UInt256(bValue));
+    }
+
+    [Test]
+    public void AddOverflow_random_uint64_values_match_BigInteger_oracle_and_aliases()
+    {
+        Random random = new(0xADD0_497);
+
+        for (int i = 0; i < 4096; i++)
+        {
+            AssertAddOverflow(new UInt256(RandomUInt64(random)), new UInt256(RandomUInt64(random)));
+        }
+    }
+
+    private static ulong RandomUInt64(Random random)
+        => ((ulong)random.NextInt64() << 1) | (uint)random.Next(2);
+
+    private static void AssertAddOverflow(UInt256 a, UInt256 b)
+    {
+        BigInteger sum = (BigInteger)a + (BigInteger)b;
+        BigInteger expectedResult = sum % TestNumbers.TwoTo256;
+        bool expectedOverflow = sum >= TestNumbers.TwoTo256;
+
+        bool overflow = UInt256.AddOverflow(in a, in b, out UInt256 result);
+        ((BigInteger)result).Should().Be(expectedResult);
+        overflow.Should().Be(expectedOverflow);
+
+        UInt256 aliasedA = a;
+        overflow = UInt256.AddOverflow(in aliasedA, in b, out aliasedA);
+        ((BigInteger)aliasedA).Should().Be(expectedResult);
+        overflow.Should().Be(expectedOverflow);
+
+        UInt256 aliasedB = b;
+        overflow = UInt256.AddOverflow(in a, in aliasedB, out aliasedB);
+        ((BigInteger)aliasedB).Should().Be(expectedResult);
+        overflow.Should().Be(expectedOverflow);
+    }
+
     public static IEnumerable<(UInt256 A, ulong A4, ulong D)> Remainder257By64BitsCases
     {
         get

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -99,6 +99,11 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
             return AddScalar(in a, in b, out res);
         }
 
+        if ((a.u1 | a.u2 | a.u3 | b.u1 | b.u2 | b.u3) == 0)
+        {
+            return AddScalarSmall(in a, in b, out res);
+        }
+
         return Avx2.IsSupported ?
             AddAvx2(in a, in b, out res) :
             AddVector256(in a, in b, out res);
@@ -130,6 +135,23 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
         AddWithCarry(a.u3, b.u3, ref c, out ulong r3);
         res = new UInt256(r0, r1, r2, r3);
         return c != 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AddScalarSmall(in UInt256 a, in UInt256 b, out UInt256 res)
+    {
+        ulong a0 = a.u0;
+        ulong u0 = a0 + b.u0;
+
+        // Assignment to res after reading a and b in case either input aliases the output.
+        res = default;
+        Unsafe.AsRef(in res.u0) = u0;
+        if (u0 < a0)
+        {
+            Unsafe.AsRef(in res.u1) = 1;
+        }
+
+        return false;
     }
 
     internal static bool AddAvx2(in UInt256 a, in UInt256 b, out UInt256 res)


### PR DESCRIPTION
## Summary

- Add a narrow scalar fast path to `UInt256.AddOverflow` when both operands have zero upper limbs.
- Preserve the existing AVX2/Vector256 path for all other inputs, including the ARM Vector256 path.
- Add deterministic BigInteger-oracle coverage for boundaries, random uint64 values, and both output aliases, plus a focused dispatch benchmark.

The public API and arithmetic semantics are unchanged. This branch is based exactly on `392d749f84ee9905d2f57fe8a83835ab48c29cc1`.

## Evidence

The matched hosted microbenchmark compares current dispatch with the gated candidate and consumes all result limbs plus the overflow flag. It uses the exact measured eligibility ratio (173,674,474 / 197,390,360 = 87.985%) as the distribution approximation.

| Case / platform | Result |
| --- | --- |
| AMD x64, hardware intrinsics, distribution | 3.062 ns -> 2.765 ns (-9.7%) |
| AMD x64, `DOTNET_EnableHWIntrinsic=0`, distribution | Neutral (2.729 ns -> 2.726 ns) |
| ARM Neoverse-N2, hardware and no intrinsics, distribution | Neutral |
| AMD x64, `Small64` hit | -48.6% |
| AMD x64, `Full` miss | +10.1% |
| Distribution-weighted local result | -14.7% |

Candidate benchmark run: [33164801546](https://github.com/NethermindEth/int256/actions/runs/33164801546)  
Exact-base matched control: [33164811406](https://github.com/NethermindEth/int256/actions/runs/33164811406)

These are library microbenchmark results, not an end-to-end RPC result. The isolated RPC benchmark [33167670976](https://github.com/NethermindEth/nethermind/actions/runs/33167670976) was cancelled before execution to prioritize the combined canonical staging A/B, so this PR makes no isolated RPC claim.

## Validation

- Focused AddOverflow tests passed: explicit zero/carry boundaries, 4096 deterministic full-range `ulong` pairs, BigInteger oracle, and output aliases through either input.
- `git diff --check` passed.
- All 13 standard pull-request test jobs passed across x64, ARM64, Windows, macOS, hardware-intrinsic, no-intrinsics, and zkEVM configurations; Publish correctly skipped.