### PR TITLE
Optimize UInt256 logical shifts on x64

### DIFF
--- a/src/Nethermind.Int256.Tests/UInt256ShiftTests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256ShiftTests.cs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.Intrinsics.X86;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nethermind.Int256.Test;
+
+public partial class UInt256Tests
+{
+    private static readonly BigInteger ShiftMask = (BigInteger.One << 256) - 1;
+
+    public static IEnumerable<TestCaseData> ShiftBoundaryCases
+    {
+        get
+        {
+            BigInteger[] values =
+            [
+                BigInteger.Zero,
+                BigInteger.One,
+                (BigInteger.One << 64) - 1,
+                (BigInteger.One << 128) + 1,
+                (BigInteger.One << 192) + (BigInteger.One << 65) + 1,
+                ShiftMask,
+            ];
+            int[] shifts =
+            [
+                -256, -192, -128, -64,
+                0, 1, 63, 64, 65,
+                127, 128, 129, 191, 192, 193,
+                255, 256, 257,
+                int.MinValue, int.MaxValue,
+            ];
+
+            foreach (BigInteger value in values)
+            {
+                foreach (int shift in shifts)
+                {
+                    yield return new TestCaseData(value, shift);
+                }
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(ShiftBoundaryCases))]
+    public void Shift_Boundaries_MatchBigInteger(BigInteger value, int shift)
+    {
+        AssertShiftMatches(value, shift);
+    }
+
+    [Test]
+    public void Shift_AllNonnegativeCounts_MatchBigIntegerOracle()
+    {
+        BigInteger[] values =
+        [
+            BigInteger.Zero,
+            BigInteger.One,
+            (BigInteger.One << 64) - 1,
+            (BigInteger.One << 128) + 1,
+            (BigInteger.One << 192) + (BigInteger.One << 65) + 1,
+            ShiftMask,
+        ];
+
+        foreach (BigInteger value in values)
+        {
+            for (int shift = 0; shift <= 256; shift++)
+            {
+                AssertShiftMatches(value, shift);
+            }
+        }
+    }
+
+    [Test]
+    public void Shift_RandomValues_MatchBigIntegerOracle()
+    {
+        Random random = new(0x256);
+        for (int i = 0; i < 256; i++)
+        {
+            byte[] bytes = new byte[32];
+            random.NextBytes(bytes);
+            BigInteger value = new(bytes, isUnsigned: true);
+            int shift = random.Next(0, 258);
+            AssertShiftMatches(value, shift);
+        }
+    }
+
+    [Test]
+    public void Shift_NegativeNonWordCounts_MatchBigIntegerWhenX64IntrinsicsAvailable()
+    {
+        if (!X86Base.X64.IsSupported)
+        {
+            Assert.Ignore("Negative non-word shifts use the legacy debug assertion when X86Base.X64 is unavailable.");
+        }
+
+        BigInteger[] values =
+        [
+            BigInteger.Zero,
+            BigInteger.One,
+            (BigInteger.One << 64) - 1,
+            (BigInteger.One << 128) + 1,
+            (BigInteger.One << 192) + (BigInteger.One << 65) + 1,
+            ShiftMask,
+        ];
+        int[] shifts = [-257, -255, -193, -191, -129, -127, -65, -63, -1];
+
+        foreach (BigInteger value in values)
+        {
+            foreach (int shift in shifts)
+            {
+                AssertShiftMatches(value, shift);
+                AssertShiftAliasingMatches(value, shift);
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(ShiftBoundaryCases))]
+    public void Shift_Aliasing_MatchesBigInteger(BigInteger value, int shift)
+    {
+        AssertShiftAliasingMatches(value, shift);
+    }
+
+    private static void AssertShiftAliasingMatches(BigInteger value, int shift)
+    {
+        UInt256 input = (UInt256)value;
+        BigInteger expectedLeft = ExpectedShift(value, shift, left: true);
+        BigInteger expectedRight = ExpectedShift(value, shift, left: false);
+
+        input.LeftShift(shift, out input);
+        ((BigInteger)input).Should().Be(expectedLeft);
+
+        input = (UInt256)value;
+        input.RightShift(shift, out input);
+        ((BigInteger)input).Should().Be(expectedRight);
+    }
+
+    private static BigInteger ExpectedShift(BigInteger value, int shift, bool left)
+    {
+        if (shift == 0)
+        {
+            return value;
+        }
+
+        if (shift < 0)
+        {
+            shift &= 63;
+            if (shift == 0)
+            {
+                return BigInteger.Zero;
+            }
+        }
+        else if (shift >= 256)
+        {
+            return BigInteger.Zero;
+        }
+
+        return (left ? value << shift : value >> shift) & ShiftMask;
+    }
+
+    private static void AssertShiftMatches(BigInteger value, int shift)
+    {
+        UInt256 input = (UInt256)value;
+        input.LeftShift(shift, out UInt256 left);
+        input.RightShift(shift, out UInt256 right);
+
+        ((BigInteger)left).Should().Be(ExpectedShift(value, shift, left: true));
+        ((BigInteger)right).Should().Be(ExpectedShift(value, shift, left: false));
+    }
+}

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -848,6 +848,12 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
 
     public static void Lsh(in UInt256 x, int n, out UInt256 res)
     {
+        if (X86Base.X64.IsSupported)
+        {
+            LshX86(in x, n, out res);
+            return;
+        }
+
         if ((n % 64) == 0)
         {
             switch (n)
@@ -934,6 +940,12 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
 
     public static void Rsh(in UInt256 x, int n, out UInt256 res)
     {
+        if (X86Base.X64.IsSupported)
+        {
+            RshX86(in x, n, out res);
+            return;
+        }
+
         // n % 64 == 0
         if ((n & 0x3f) == 0)
         {
@@ -1015,6 +1027,148 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
         z0 = NativeRsh(res.u0, n) | a;
 
         res = new UInt256(z0, z1, z2, z3);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void LshX86(in UInt256 x, int n, out UInt256 res)
+    {
+        if ((n & 63) == 0)
+        {
+            switch (n)
+            {
+                case 0:
+                    res = x;
+                    return;
+                case 64:
+                    x.Lsh64(out res);
+                    return;
+                case 128:
+                    x.Lsh128(out res);
+                    return;
+                case 192:
+                    x.Lsh192(out res);
+                    return;
+                default:
+                    res = Zero;
+                    return;
+            }
+        }
+
+        int wordShift;
+        if (n < 0)
+        {
+            // Preserve the existing behavior for negative counts: negative multiples of 64
+            // returned zero, while all other negative counts behaved as a shift by n & 63.
+            n &= 63;
+            if (n == 0)
+            {
+                res = Zero;
+                return;
+            }
+            wordShift = 0;
+        }
+        else
+        {
+            if (n >= 256)
+            {
+                res = Zero;
+                return;
+            }
+            wordShift = n >> 6;
+        }
+
+        int bitShift = n & 63;
+        int inverseShift = 64 - bitShift;
+        res = wordShift switch
+        {
+            0 => new UInt256(
+                x.u0 << bitShift,
+                (x.u1 << bitShift) | (x.u0 >> inverseShift),
+                (x.u2 << bitShift) | (x.u1 >> inverseShift),
+                (x.u3 << bitShift) | (x.u2 >> inverseShift)),
+            1 => new UInt256(
+                0,
+                x.u0 << bitShift,
+                (x.u1 << bitShift) | (x.u0 >> inverseShift),
+                (x.u2 << bitShift) | (x.u1 >> inverseShift)),
+            2 => new UInt256(
+                0,
+                0,
+                x.u0 << bitShift,
+                (x.u1 << bitShift) | (x.u0 >> inverseShift)),
+            _ => new UInt256(0, 0, 0, x.u0 << bitShift),
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void RshX86(in UInt256 x, int n, out UInt256 res)
+    {
+        if ((n & 63) == 0)
+        {
+            switch (n)
+            {
+                case 0:
+                    res = x;
+                    return;
+                case 64:
+                    x.Rsh64(out res);
+                    return;
+                case 128:
+                    x.Rsh128(out res);
+                    return;
+                case 192:
+                    x.Rsh192(out res);
+                    return;
+                default:
+                    res = Zero;
+                    return;
+            }
+        }
+
+        int wordShift;
+        if (n < 0)
+        {
+            // Preserve the existing behavior for negative counts: negative multiples of 64
+            // returned zero, while all other negative counts behaved as a shift by n & 63.
+            n &= 63;
+            if (n == 0)
+            {
+                res = Zero;
+                return;
+            }
+            wordShift = 0;
+        }
+        else
+        {
+            if (n >= 256)
+            {
+                res = Zero;
+                return;
+            }
+            wordShift = n >> 6;
+        }
+
+        int bitShift = n & 63;
+        int inverseShift = 64 - bitShift;
+        res = wordShift switch
+        {
+            0 => new UInt256(
+                (x.u0 >> bitShift) | (x.u1 << inverseShift),
+                (x.u1 >> bitShift) | (x.u2 << inverseShift),
+                (x.u2 >> bitShift) | (x.u3 << inverseShift),
+                x.u3 >> bitShift),
+            1 => new UInt256(
+                (x.u1 >> bitShift) | (x.u2 << inverseShift),
+                (x.u2 >> bitShift) | (x.u3 << inverseShift),
+                x.u3 >> bitShift,
+                0),
+            2 => new UInt256(
+                (x.u2 >> bitShift) | (x.u3 << inverseShift),
+                x.u3 >> bitShift,
+                0,
+                0),
+            _ => new UInt256(x.u3 >> bitShift, 0, 0, 0),
+        };
     }
 
     public void RightShift(int n, out UInt256 res) => Rsh(this, n, out res);


### PR DESCRIPTION
## Summary

- Keep the origin/main logical-shift implementation as the default on ARM64 and when x64 hardware intrinsics are disabled.
- Dispatch to a direct-limb implementation only when `X86Base.X64.IsSupported`.
- Preserve word-shift fast paths and existing negative-count, boundary, and aliasing semantics.

## Correctness

The focused shift suite passed on the final PR head (`8baac47`):

- default release: 243/243
- default debug: 243/243
- no-HW release: 242/243 (one expected compatibility-test skip when X86Base.X64 is unavailable)
- no-HW debug: 242/243 (one expected compatibility-test skip when X86Base.X64 is unavailable)

The tests cover BigInteger oracles for all nonnegative counts 0..256, negative word-multiple boundaries, deterministic random values, and output aliasing across targets. Negative non-word compatibility cases, including aliasing, are isolated to an X86Base.X64.IsSupported test because the unchanged legacy fallback intentionally asserts on those derived debug shift counts.

## Hosted microbenchmark evidence

The durable A/B harness was run from workflow-only evidence branches and removed from the PR branch after proof collection to keep this PR limited to production code and tests. The evidence source is behavior-identical to this PR head; only the benchmark file/workflow commit is absent from the PR.

- Candidate: [`bench-run/shifts-candidate-x86only-cc8a702`](https://github.com/NethermindEth/int256/tree/bench-run/shifts-candidate-x86only-cc8a702), source `cc8a702`, workflow head `3cc977ca393ba5abfc27d79fc5bea818cb7e8a30`, [run 33175200432](https://github.com/NethermindEth/int256/actions/runs/33175200432)
- Exact base: [`bench-run/shifts-base-x86only-c020944`](https://github.com/NethermindEth/int256/tree/bench-run/shifts-base-x86only-c020944), production source `392d749`, benchmark-harness head `b3adc40d3885e43127a51f129db852e054a02d61`, [run 33175617930](https://github.com/NethermindEth/int256/actions/runs/33175617930)

The benchmark consumes the full result and setup equality is checked. `CorpusWeighted` uses the captured 497-corpus rates: 88.54% non-word Lsh counts and 68.17% non-word Rsh counts. `Job-WNYDVS` is HW and `Job-SAEUUJ` is no-HW.

| Host / mode | Lsh exact-base Current -> candidate Current | Rsh exact-base Current -> candidate Current |
| --- | ---: | ---: |
| AMD64 HW | 8.759 -> 5.805 ns (-33.73%) | 8.854 -> 6.240 ns (-29.52%) |
| AMD64 no-HW | 5.072 -> 5.123 ns (+1.01%) | 5.310 -> 5.308 ns (-0.04%) |
| ARM64 HW | 4.175 -> 4.204 ns (+0.69%) | 4.273 -> 4.267 ns (-0.14%) |
| ARM64 no-HW | 4.171 -> 4.203 ns (+0.77%) | 4.264 -> 4.280 ns (+0.38%) |

AMD64 HW per-workload candidate-vs-exact-base deltas:

- Lsh: NonWord -46.29%, Word64 -24.90%, Word128 -32.40%, Word192 -32.75%, Zero -40.89%, OutOfRange256 -51.84%, OutOfRange257 -57.12%.
- Rsh: NonWord -39.41%, Word64 -36.15%, Word128 -25.49%, Word192 -34.16%, Zero -41.39%, OutOfRange256 -51.97%, OutOfRange257 -52.30%.

The ARM64 and no-HW weighted controls are all within 1% of exact-base Current. Individual ARM no-HW Word128 measurements were noisy (large error), but the weighted controls remain neutral.

## JIT/code-size check

With tiering disabled and `COMPlus_JitDisasm` on the evidence build:

- x64 HW `UInt256.Lsh`: 825 bytes; prior direct-only candidate: 826 bytes.
- x64 HW `UInt256.Rsh`: 903 bytes; prior direct-only candidate: 902 bytes.
- x64 no-HW `Lsh`/`Rsh`: 461/495 bytes, showing the legacy body is selected.

The x64 hot path is therefore not materially enlarged by the architecture gate. JIT disassembly showed the `X86Base.X64.IsSupported` check folded away: x64 contains only the direct helper body, while no-HW contains only the legacy fallback. The disassembly check ran on a local Intel host and is only a JIT-shape check, not a cross-CPU timing claim.