### PR TITLE
Optimize UInt256 division by power-of-two divisors

### DIFF
--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -653,6 +653,75 @@ public partial class UInt256Tests : UInt256TestsTemplate<UInt256>
 
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
 
+    [Test]
+    public void DivideAndMod_PowerOfTwoDivisors_MatchBigInteger()
+    {
+        UInt256[] boundaryValues =
+        [
+            UInt256.Zero,
+            UInt256.One,
+            new UInt256(ulong.MaxValue),
+            new UInt256(0, 1),
+            new UInt256(0, 0, 1),
+            UInt256.MaxValue - 1,
+            UInt256.MaxValue,
+        ];
+
+        for (int shift = 0; shift < 64; shift++)
+        {
+            ulong divisor = 1UL << shift;
+            UInt256 divisorValue = new(divisor);
+
+            foreach (UInt256 value in boundaryValues)
+            {
+                AssertResult(in value, in divisorValue, divisor);
+            }
+
+            AssertResult(new UInt256(divisor - 1), in divisorValue, divisor);
+            AssertResult(new UInt256(divisor + 1), in divisorValue, divisor);
+        }
+
+        Random random = new(0xD1B1DE);
+        byte[] bytes = new byte[32];
+        for (int i = 0; i < 4096; i++)
+        {
+            random.NextBytes(bytes);
+            UInt256 value = new(bytes);
+            ulong divisor = 1UL << random.Next(64);
+            UInt256 divisorValue = new(divisor);
+            AssertResult(in value, in divisorValue, divisor);
+        }
+
+        static void AssertResult(in UInt256 value, in UInt256 divisor, ulong divisorValue)
+        {
+            BigInteger dividendBigInteger = (BigInteger)value;
+            BigInteger divisorBigInteger = divisorValue;
+            BigInteger expectedQuotient = dividendBigInteger / divisorBigInteger;
+            BigInteger expectedRemainder = dividendBigInteger % divisorBigInteger;
+
+            value.Divide(divisor, out UInt256 quotient);
+            value.Mod(divisor, out UInt256 remainder);
+            ((BigInteger)quotient).Should().Be(expectedQuotient);
+            ((BigInteger)remainder).Should().Be(expectedRemainder);
+
+            UInt256 aliasedValue = value;
+            aliasedValue.Divide(divisor, out aliasedValue);
+            ((BigInteger)aliasedValue).Should().Be(expectedQuotient);
+
+            aliasedValue = value;
+            aliasedValue.Mod(divisor, out aliasedValue);
+            ((BigInteger)aliasedValue).Should().Be(expectedRemainder);
+
+            UInt256 aliasedDivisor = divisor;
+            value.Divide(aliasedDivisor, out aliasedDivisor);
+            ((BigInteger)aliasedDivisor).Should().Be(expectedQuotient);
+
+            aliasedDivisor = divisor;
+            value.Mod(aliasedDivisor, out aliasedDivisor);
+            ((BigInteger)aliasedDivisor).Should().Be(expectedRemainder);
+        }
+    }
+
     public static IEnumerable<(UInt256 A, ulong A4, ulong D)> Remainder257By64BitsCases
     {
         get

--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -654,7 +654,7 @@ public partial class UInt256Tests : UInt256TestsTemplate<UInt256>
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
 
     [Test]
-    public void DivideAndMod_PowerOfTwoDivisors_MatchBigInteger()
+    public void DivideAndMod_SingleLimbPowerOfTwoDivisors_MatchBigInteger()
     {
         UInt256[] boundaryValues =
         [

--- a/src/Nethermind.Int256/UInt256.DivideMod.cs
+++ b/src/Nethermind.Int256/UInt256.DivideMod.cs
@@ -2390,7 +2390,11 @@ public readonly partial struct UInt256
         }
         else
         {
-            if (X86Base.X64.IsSupported)
+            if ((y.u0 & (y.u0 - 1)) == 0)
+            {
+                DivideByPowerOfTwo(in x, y.u0, out quotient, out remainder);
+            }
+            else if (X86Base.X64.IsSupported)
             {
                 DivideBy64BitsX86Base(in x, y.u0, out quotient, out remainder);
             }
@@ -2467,6 +2471,26 @@ public readonly partial struct UInt256
         // Unnormalise remainder (single limb)
         ulong r0 = rem >> s;
         remainder = Create(r0, 0, 0, 0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DivideByPowerOfTwo(in UInt256 x, ulong divisor, out UInt256 q, out UInt256 remainder)
+    {
+        ulong x0 = x.u0;
+        ulong x1 = x.u1;
+        ulong x2 = x.u2;
+        ulong x3 = x.u3;
+        int shift = BitOperations.TrailingZeroCount(divisor);
+        ulong mask = divisor - 1;
+
+        int inverseShift = 64 - shift;
+        q = Create(
+            (x0 >> shift) | (x1 << inverseShift),
+            (x1 >> shift) | (x2 << inverseShift),
+            (x2 >> shift) | (x3 << inverseShift),
+            x3 >> shift);
+
+        remainder = Create(x0 & mask, 0, 0, 0);
     }
 
     [SkipLocalsInit]


### PR DESCRIPTION
## Summary

- Add a private aggressively-inlined power-of-two divisor path for the existing one-limb `UInt256` divide/mod kernel.
- Dispatch from the existing one-limb arm of `DivideImpl`, so wide-divisor paths and the public `divisor == 1` fast path retain their existing control flow.
- The helper computes quotient shifts and the low-limb remainder mask directly, preserving output aliasing and modulo semantics.
- Add deterministic boundary/random BigInteger-oracle coverage, including output aliasing for both `Divide` and `Mod`.

## Hosted benchmark evidence

The candidate and exact-main control used the identical harness (`SHA256 00039C122138E63BB86E8E420D10DB92A75E14A66AD054487BC767C06FC3C775`) and the same 2-launch/2-warmup/8-iteration jobs. Each case consumes all output limbs. Candidate proof head: `7ff2308`; exact-base proof head: `455a0a6`.

- Candidate run: https://github.com/NethermindEth/int256/actions/runs/33191438097 (AMD job 98917629067, ARM job 98917628815)
- Exact-base run: https://github.com/NethermindEth/int256/actions/runs/33191434699 (AMD job 98917617747, ARM job 98917617349)

Values below are exact-base Current -> candidate Current in ns/op. Hit aggregates average the five reachable shifts (1, 7, 31, 32, 63); miss aggregates average the three non-power controls (3, 10, large), with equal case weighting. `no-HW` means `DOTNET_EnableHWIntrinsic=0`.

| Host/mode | Hit Divide | Hit Mod | Miss Divide | Miss Mod |
| --- | ---: | ---: | ---: | ---: |
| AMD HW | 14.597 -> 7.022 (-51.9%) | 16.162 -> 8.073 (-50.0%) | 14.498 -> 14.589 (+0.6%) | 16.095 -> 16.037 (-0.4%) |
| AMD no-HW | 61.367 -> 7.437 (-87.9%) | 62.960 -> 9.054 (-85.6%) | 61.692 -> 61.924 (+0.4%) | 63.919 -> 63.899 (0.0%) |
| ARM HW | 21.697 -> 5.263 (-75.7%) | 23.509 -> 6.771 (-71.2%) | 21.921 -> 22.031 (+0.5%) | 23.814 -> 23.877 (+0.3%) |
| ARM no-HW | 39.821 -> 5.272 (-86.8%) | 43.278 -> 6.771 (-84.4%) | 39.873 -> 40.343 (+1.2%) | 42.851 -> 42.960 (+0.3%) |

Per-shift hit deltas (shifts 1/7/31/32/63):

- AMD HW Divide: -51.1/-51.6/-52.8/-51.9/-52.1%; Mod: -49.3/-51.1/-49.4/-50.0/-50.4%.
- AMD no-HW Divide: -87.9/-88.0/-87.8/-88.0/-87.8%; Mod: -85.7/-85.8/-85.3/-85.7/-85.5%.
- ARM HW Divide: -75.6/-75.7/-75.8/-75.8/-75.7%; Mod: -71.2/-71.3/-71.4/-71.3/-70.8%.
- ARM no-HW Divide: -86.9/-86.8/-86.7/-86.9/-86.6%; Mod: -84.4/-84.4/-84.5/-84.4/-84.1%.

The `divisor == 1` public-wrapper control remains outside `DivideImpl`: AMD HW Divide +0.1%, Mod +10.5%; AMD no-HW Divide +2.1%, Mod +1.2%; ARM HW Divide 0.0%, Mod -0.4%; ARM no-HW Divide 0.0%, Mod +0.3%. The AMD Mod control is small cross-run noise, not an affected path.

These are arithmetic microbenchmarks only. No RPC benchmark or corpus-level eligibility/performance claim is made in this PR; exact full-kernel incidence is still being measured separately.

## Verification

- `dotnet build src/Nethermind.Int256.Benchmark/Nethermind.Int256.Benchmark.csproj -c Release --no-restore`
- Full `Nethermind.Int256.Tests`: default 575,823 passed; no-HW 575,822 passed, 1 expected hardware-unavailable skip.
- Hosted Benchmark workflow succeeded on both AMD (`ubuntu-latest`) and ARM (`ubuntu-24.04-arm`) for HW and no-HW jobs.