### PR TITLE
Optimize one-limb subtraction on portable paths

### DIFF
--- a/src/Nethermind.Int256.Tests/UInt256Tests.cs
+++ b/src/Nethermind.Int256.Tests/UInt256Tests.cs
@@ -653,6 +653,67 @@ public partial class UInt256Tests : UInt256TestsTemplate<UInt256>
 
     public UInt256Tests() : base((BigInteger x) => (UInt256)x, (int x) => (UInt256)x, x => x, TestNumbers.UInt256Max) { }
 
+    public static IEnumerable<(UInt256 A, ulong B)> SubtractByUInt64Cases =>
+    [
+        (new UInt256(0, 0, 0, 0), 0),
+        (new UInt256(1, 0, 0, 0), 1),
+        (new UInt256(0, 1, 0, 0), 1),
+        (new UInt256(0, 0, 1, 0), 1),
+        (new UInt256(0, 0, 0, 1), 1),
+        (new UInt256(0, 0, 0, 0), 1),
+        (new UInt256(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue), ulong.MaxValue),
+    ];
+
+    [TestCaseSource(nameof(SubtractByUInt64Cases))]
+    public void SubtractUnderflow_right_uint64_values_preserve_result_underflow_and_aliases((UInt256 A, ulong B) test)
+    {
+        AssertSubtractUnderflow(test.A, new UInt256(test.B));
+    }
+
+    [Test]
+    public void SubtractUnderflow_random_full_left_and_uint64_right_match_BigInteger_oracle_and_aliases()
+    {
+        Random random = new(0x5AB7_497);
+
+        for (int i = 0; i < 4096; i++)
+        {
+            UInt256 a = new UInt256(
+                RandomSubtractOperand(random),
+                RandomSubtractOperand(random),
+                RandomSubtractOperand(random),
+                RandomSubtractOperand(random));
+            AssertSubtractUnderflow(a, new UInt256(RandomSubtractOperand(random)));
+        }
+    }
+
+    private static ulong RandomSubtractOperand(Random random)
+        => ((ulong)random.NextInt64() << 1) | (uint)random.Next(2);
+
+    private static void AssertSubtractUnderflow(UInt256 a, UInt256 b)
+    {
+        BigInteger difference = (BigInteger)a - (BigInteger)b;
+        BigInteger expectedResult = difference % TestNumbers.TwoTo256;
+        if (expectedResult.Sign < 0)
+        {
+            expectedResult += TestNumbers.TwoTo256;
+        }
+        bool expectedUnderflow = difference.Sign < 0;
+
+        bool underflow = UInt256.SubtractUnderflow(in a, in b, out UInt256 result);
+        ((BigInteger)result).Should().Be(expectedResult);
+        underflow.Should().Be(expectedUnderflow);
+
+        UInt256 aliasedA = a;
+        underflow = UInt256.SubtractUnderflow(in aliasedA, in b, out aliasedA);
+        ((BigInteger)aliasedA).Should().Be(expectedResult);
+        underflow.Should().Be(expectedUnderflow);
+
+        UInt256 aliasedB = b;
+        underflow = UInt256.SubtractUnderflow(in a, in aliasedB, out aliasedB);
+        ((BigInteger)aliasedB).Should().Be(expectedResult);
+        underflow.Should().Be(expectedUnderflow);
+    }
+
     public static IEnumerable<(UInt256 A, ulong A4, ulong D)> Remainder257By64BitsCases
     {
         get

--- a/src/Nethermind.Int256/UInt256.cs
+++ b/src/Nethermind.Int256/UInt256.cs
@@ -327,6 +327,11 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
         }
         else
         {
+            if (b.u1 == 0 && b.u2 == 0 && b.u3 == 0)
+            {
+                return SubtractByUInt64(in a, b.u0, out res);
+            }
+
             ulong borrow = 0ul;
             SubtractWithBorrow(a.u0, b.u0, ref borrow, out ulong res0);
             SubtractWithBorrow(a.u1, b.u1, ref borrow, out ulong res1);
@@ -335,6 +340,56 @@ public readonly partial struct UInt256 : IEquatable<UInt256>, IComparable, IComp
             res = new UInt256(res0, res1, res2, res3);
             return borrow != 0;
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool SubtractByUInt64(in UInt256 a, ulong b0, out UInt256 res)
+    {
+        ulong a0 = a.u0;
+        ulong result0 = a0 - b0;
+        if (a0 >= b0)
+        {
+            res = a;
+            Unsafe.AsRef(in res.u0) = result0;
+            return false;
+        }
+
+        ulong a1 = a.u1;
+        if (a1 != 0)
+        {
+            res = a;
+            Unsafe.AsRef(in res.u0) = result0;
+            Unsafe.AsRef(in res.u1) = a1 - 1;
+            return false;
+        }
+
+        ulong a2 = a.u2;
+        if (a2 != 0)
+        {
+            res = a;
+            Unsafe.AsRef(in res.u0) = result0;
+            Unsafe.AsRef(in res.u1) = ulong.MaxValue;
+            Unsafe.AsRef(in res.u2) = a2 - 1;
+            return false;
+        }
+
+        ulong a3 = a.u3;
+        if (a3 != 0)
+        {
+            res = a;
+            Unsafe.AsRef(in res.u0) = result0;
+            Unsafe.AsRef(in res.u1) = ulong.MaxValue;
+            Unsafe.AsRef(in res.u2) = ulong.MaxValue;
+            Unsafe.AsRef(in res.u3) = a3 - 1;
+            return false;
+        }
+
+        res = default;
+        Unsafe.AsRef(in res.u0) = result0;
+        Unsafe.AsRef(in res.u1) = ulong.MaxValue;
+        Unsafe.AsRef(in res.u2) = ulong.MaxValue;
+        Unsafe.AsRef(in res.u3) = ulong.MaxValue;
+        return true;
     }
 
     public void Subtract(in UInt256 b, out UInt256 res) => Subtract(this, b, out res);


### PR DESCRIPTION
## Summary
- Keep the existing AVX2 `SubtractImpl` path unchanged.
- On scalar, ARM, and no-intrinsics fallback only, detect a one-limb right operand and use a borrow-propagating scalar subtraction.
- Preserve wrapped-result, underflow, and input/output aliasing semantics with focused BigInteger-oracle tests.

## Evidence
The exact captured corpus shows right-operand significant width <= 1 in 35,512,486 / 47,023,532 calls (75.521%). A matched proof used byte-identical harness source (SHA-256 `A3A4E5E5615CEAA3A2959FA8213A308715114854ABFABF784FD559F093C51C7F`):

| Host / mode | Distribution Current -> candidate | Full miss Current -> candidate |
| --- | ---: | ---: |
| ARM Neoverse-N2 HW | 4.216 -> 2.455 ns (-41.8%) | 4.220 -> 4.556 ns (+8.0%) |
| ARM Neoverse-N2 no-HW | 4.217 -> 2.456 ns (-41.8%) | 4.218 -> 4.556 ns (+8.0%) |
| AMD HW (AVX2) | 3.305 -> 3.241 ns (-1.9%) | 3.267 -> 3.273 ns (+0.2%) |
| AMD no-HW | 5.488 -> 3.260 ns (-40.6%) | 5.489 -> 6.053 ns (+10.3%) |

ARM individual hit cases improved 50.8%–58.3%. The AMD HW result is reported as neutral only: the AVX2 branch is source-unchanged and the proof jobs used different AMD feature tiers. The 75.521% mixture projects approximately 42% portable/ARM improvement.

Proof runs: [base 33193308218](https://github.com/NethermindEth/int256/actions/runs/33193308218), [candidate 33193338826](https://github.com/NethermindEth/int256/actions/runs/33193338826). Both AMD and ARM jobs passed.

## Validation
- Focused subtraction tests: 8/8 passed in normal and `DOTNET_EnableHWIntrinsic=0` modes.
- Full `Nethermind.Int256.Tests`: 575,830 passed normal; 575,829 passed no-HW, with one expected hardware-dependent skip.
- AMD JIT capture after relocation emits the existing AVX2 vector body (98 bytes); the new gate is below that branch.
- Public API and behavior are unchanged.
- No RPC benchmark claim is made; no package was staged or published.